### PR TITLE
Tear Down client when Split Factory Component Unmounts

### DIFF
--- a/src/SplitFactory.tsx
+++ b/src/SplitFactory.tsx
@@ -100,6 +100,10 @@ class SplitFactory extends React.Component<ISplitFactoryProps, ISplitContextValu
     this.setState({ lastUpdate: Date.now() });
   }
 
+  componentWillUnmount() {
+    this.state.client?.destroy();
+  }
+
   render() {
     const { children } = this.props;
     const { factory, isReady, isTimedout, lastUpdate } = this.state;

--- a/src/__tests__/SplitFactory.test.tsx
+++ b/src/__tests__/SplitFactory.test.tsx
@@ -236,12 +236,30 @@ describe('SplitFactory', () => {
     const errorSpy = jest.spyOn(console, 'error');
     mount(
       <SplitFactory>
-        {({factory}) => {
+        {({ factory }) => {
           expect(factory).toBe(null);
           return null;
         }}
       </SplitFactory>);
     expect(errorSpy).toBeCalledWith(ERROR_SF_NO_CONFIG_AND_FACTORY);
+  });
+
+  test('cleans up on unmount.', () => {
+    // let destroySpy;
+    const outerFactory = SplitSdk(sdkBrowser);
+    getClientWithStatus(outerFactory);
+    (outerFactory as any).client().__emitter__.emit(Event.SDK_READY);
+    const wrapper = mount(
+      <SplitFactory>
+        {({ factory }) => {
+          expect(outerFactory).toBe(outerFactory);
+          console.log(outerFactory.client());
+          // destroySpy = jest.spyOn(outerFactory.client(), 'destroy');
+          return null;
+        }}
+      </SplitFactory>);
+    wrapper.unmount();
+    // expect(destroySpy).toBeCalled();
   });
 
   /**


### PR DESCRIPTION
# React SDK

## What did you accomplish?
If / when the component unmounts, the client (event emitter) is leaked. This change cleans up the client on unmount.

## How do we test the changes introduced in this PR?
Would a spy on `client.destroy()` suffice? I have made an attempt, please see the split-out fixup commit. I will give it another shot soon, but you might be able to help quicker.

## Extra Notes
The larger issue is that there are cases where the `id` prop changes. Example scenario: a user begins unauthenticated, and is given a temporary split id. The use logs in and now their split id can be set to an id the application can identify the user with.

For a SPA, the `SplitFactory` element remains mounted, but a new id is passed. If I understand correctly, this component does not react to any prop changes once mounted. So a stop-gap solution is to set the element's [`key`](https://reactjs.org/docs/lists-and-keys.html#keys) to the same as `id` to tell (or trick) React to un-mount the existing `SplitFactory` instance and mount a new one with the new id. This change is a good idea regardless. `componentDidUpdate` (or a hooks migration) can be implemented at a later time.