### PR TITLE
Fix and split context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ deploy:
     acl: public_read
     cache_control: "max-age=31536000, public"
     on:
-      branch: fix_and_split_context
+      branch: development
   - provider: s3
     access_key_id: ${AWS_ACCESS_KEY_ID_PROD}
     secret_access_key: ${AWS_SECRET_ACCESS_PROD}

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ deploy:
     acl: public_read
     cache_control: "max-age=31536000, public"
     on:
-      branch: development
+      branch: fix_and_split_context
   - provider: s3
     access_key_id: ${AWS_ACCESS_KEY_ID_PROD}
     secret_access_key: ${AWS_SECRET_ACCESS_PROD}

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,2 +1,6 @@
+1.1.0 (March 9, 2020)
+ - Exported `SplitContext` to access Split readiness state when using React hooks.
+ - Bugfixing - issue with SDK_READY_TIMED_OUT events.
+
 1.0.0 (January 24, 2020)
  - Initial public release!

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-1.1.0 (March 9, 2020)
+1.1.0 (March 11, 2020)
  - Exported `SplitContext` to access Split readiness state when using React hooks.
  - Bugfixing - issue with SDK_READY_TIMED_OUT events.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "A React library to easily integrate and use Split JS SDK",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/splitio/react-sdk-library.git"
+    "url": "git+https://github.com/splitio/react-client.git"
   },
   "keywords": [
     "splitio",
@@ -54,9 +54,9 @@
   ],
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/splitio/react-sdk-library/issues"
+    "url": "https://github.com/splitio/react-client/issues"
   },
-  "homepage": "https://github.com/splitio/react-sdk-library#readme",
+  "homepage": "https://github.com/splitio/react-client#readme",
   "dependencies": {
     "@splitsoftware/splitio": "10.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.0.0",
+  "version": "1.1.0-canary.0",
   "description": "A React library to easily integrate and use Split JS SDK",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/SplitClient.tsx
+++ b/src/SplitClient.tsx
@@ -62,7 +62,7 @@ class SplitClient extends React.Component<ISplitClientProps & { splitContext: IS
         if (this.state.client === client && updateOnSdkReady) {
           this.setState({ isReady: true, isTimedout: false, lastUpdate: Date.now() });
         }
-      }).catch(() => {
+      }, () => {
         // Update isTimedout if the client was not changed and updateOnSdkTimedout is true
         if (this.state.client === client) {
           if (updateOnSdkTimedout) {

--- a/src/SplitFactory.tsx
+++ b/src/SplitFactory.tsx
@@ -73,7 +73,7 @@ class SplitFactory extends React.Component<ISplitFactoryProps, ISplitContextValu
         if (this.state.client === client && updateOnSdkReady) {
           this.setState({ isReady: true, isTimedout: false, lastUpdate: Date.now() });
         }
-      }).catch(() => {
+      }, () => {
         // Update isTimedout if the client was not changed and updateOnSdkTimedout is true
         if (this.state.client === client) {
           if (updateOnSdkTimedout) {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,0 +1,57 @@
+import {
+  SplitContext as ExportedSplitContext,
+  SplitSdk as ExportedSplitSdk,
+  SplitFactory as ExportedSplitFactory,
+  SplitClient as ExportedSplitClient,
+  SplitTreatments as ExportedSplitTreatments,
+  withSplitFactory as exportedWithSplitFactory,
+  withSplitClient as exportedWithSplitClient,
+  withSplitTreatments as exportedWithSplitTreatments,
+  useClient as exportedUseClient,
+  useManager as exportedUseManager,
+  useTrack as exportedUseTrack,
+  useTreatments as exportedUseTreatments,
+} from '../index';
+import SplitContext from '../SplitContext';
+import { SplitFactory as SplitioEntrypoint } from '@splitsoftware/splitio';
+import SplitFactory from '../SplitFactory';
+import SplitClient from '../SplitClient';
+import SplitTreatments from '../SplitTreatments';
+import withSplitFactory from '../withSplitFactory';
+import withSplitClient from '../withSplitClient';
+import withSplitTreatments from '../withSplitTreatments';
+import useClient from '../useClient';
+import useManager from '../useManager';
+import useTrack from '../useTrack';
+import useTreatments from '../useTreatments';
+
+describe('index', () => {
+
+  it('should export components', () => {
+    expect(ExportedSplitFactory).toBe(SplitFactory);
+    expect(ExportedSplitClient).toBe(SplitClient);
+    expect(ExportedSplitTreatments).toBe(SplitTreatments);
+  });
+
+  it('should export HOCs', () => {
+    expect(exportedWithSplitFactory).toBe(withSplitFactory);
+    expect(exportedWithSplitClient).toBe(withSplitClient);
+    expect(exportedWithSplitTreatments).toBe(withSplitTreatments);
+  });
+
+  it('should export hooks', () => {
+    expect(exportedUseClient).toBe(useClient);
+    expect(exportedUseManager).toBe(useManager);
+    expect(exportedUseTrack).toBe(useTrack);
+    expect(exportedUseTreatments).toBe(useTreatments);
+  });
+
+  it('should export SplitContext', () => {
+    expect(ExportedSplitContext).toBe(SplitContext);
+  });
+
+  it('should export Splitio entrypoint', () => {
+    expect(ExportedSplitSdk).toBe(SplitioEntrypoint);
+  });
+
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,10 @@ export { default as SplitClient } from './SplitClient';
 export { default as SplitFactory } from './SplitFactory';
 
 // helper functions/hooks
-export { default as useClient} from './useClient';
-export { default as useTreatments} from './useTreatments';
-export { default as useTrack} from './useTrack';
-export { default as useManager} from './useManager';
+export { default as useClient } from './useClient';
+export { default as useTreatments } from './useTreatments';
+export { default as useTrack } from './useTrack';
+export { default as useManager } from './useManager';
+
+// SplitContext
+export { default as SplitContext } from './SplitContext';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ export function getClientWithStatus(factory: SplitIO.ISDK, key?: SplitIO.SplitKe
     // We cannot use event listeners, since clients might be already Ready or Timedout
     client.ready().then(() => {
       client.isReady = true;
-    }).catch(() => {
+    }, () => {
       client.isTimedout = true;
       // register a listener for SDK_READY event, that might trigger after a timeout
       client.once(client.Event.SDK_READY, () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,3 +9,4 @@ export { default as useClient } from './useClient';
 export { default as useTreatments } from './useTreatments';
 export { default as useTrack } from './useTrack';
 export { default as useManager } from './useManager';
+export { default as SplitContext } from './SplitContext';

--- a/umd.ts
+++ b/umd.ts
@@ -17,9 +17,13 @@ import useTreatments from './src/useTreatments';
 import useTrack from './src/useTrack';
 import useManager from './src/useManager';
 
+// SplitContext
+import SplitContext from './src/SplitContext';
+
 export default {
   SplitSdk,
   withSplitFactory, withSplitClient, withSplitTreatments,
   SplitFactory, SplitClient, SplitTreatments,
-  useClient, useTreatments, useTrack, useManager
+  useClient, useTreatments, useTrack, useManager,
+  SplitContext,
 };


### PR DESCRIPTION
# React SDK

## What did you accomplish?

- Fix issue with SDK_READY_TIMED_OUT events on browsers, by updating how we handle `client.ready()` promise.
- Export `SplitContext` to access SDK status synchronously when using hooks (e.g., `let { isReady } = useContext(SplitContext);`).

## How do we test the changes introduced in this PR?

- Tests already cover cases with SDK_READY_TIMED_OUT event. 
- Added a test to check that modules are exported correctly.

## Extra Notes