### PR TITLE
Input validation for split names when the Sdk is not operational

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+1.2.2 (December XXX, 2020)
+ - Updated @splitsoftware/splitio dependency to version 10.15.2.
+ - Updated internal validation to avoid errors when passing an invalid list of split names to `SplitTreatments` component and `useTreatments` hook.
+
 1.2.1 (Oct 7, 2020)
  - Updated @splitsoftware/splitio dependency to version 10.15.0, which uses the optimized impressions sending and supports filtering the splits to be synced. Learn more in our javascript-client changelog or documentation.
  - Updated some NPM dependencies mostly for vulnerability fixes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.2.1",
+  "version": "1.2.2-canary.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -303,9 +303,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -1450,16 +1450,16 @@
       }
     },
     "@splitsoftware/splitio": {
-      "version": "10.15.0",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-10.15.0.tgz",
-      "integrity": "sha512-HMxTozeTJl2huiMljqQ7iW2jqL9zimz/0Jrh9x9jnu7PtKx6kCWnAnQjP9KcZPoOg6bzfvUg7BfZhEmphpLLkQ==",
+      "version": "10.15.2",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-10.15.2.tgz",
+      "integrity": "sha512-5dRtnw0gkMwkgGIJl+eILjYi8sUA7+r3TJog3LXfa9I+/u5ct2Zh8X30q97R+e10Mi59xqZp5lhQEIytGAIN9w==",
       "requires": {
         "@babel/runtime": "^7.10.2",
         "@types/google.analytics": "0.0.40",
         "@types/node": "^13.9.1",
         "events": "3.1.0",
         "eventsource": "^1.0.7",
-        "ioredis": "^4.14.1",
+        "ioredis": "4.18.0",
         "ip": "1.1.5",
         "js-yaml": "3.13.1",
         "node-fetch": "^2.6.1",
@@ -1469,9 +1469,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.23",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.23.tgz",
-          "integrity": "sha512-L31WmMJYKb15PDqFWutn8HNwrNK6CE6bkWgSB0dO1XpNoHrszVKV1Clcnfgd6c/oG54TVF8XQEvY2gQrW8K6Mw=="
+          "version": "13.13.34",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.34.tgz",
+          "integrity": "sha512-g8D1HF2dMDKYSDl5+79izRwRgNPsSynmWMbj50mj7GZ0b7Lv4p8EmZjbo3h0h+6iLr6YmVz9VnF6XVZ3O6V1Ug=="
         },
         "events": {
           "version": "3.1.0",
@@ -5158,16 +5158,16 @@
       "dev": true
     },
     "ioredis": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.17.3.tgz",
-      "integrity": "sha512-iRvq4BOYzNFkDnSyhx7cmJNOi1x/HWYe+A4VXHBu4qpwJaGT1Mp+D2bVGJntH9K/Z/GeOM/Nprb8gB3bmitz1Q==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.18.0.tgz",
+      "integrity": "sha512-wXlB60wD+ayJxbD7t+RFBanXinhHyYpfKUxTEEXNOpd0wb+nC8GLH2r7SaZ6sSBOxr8x6jDfBiuMaiK3bPYABw==",
       "requires": {
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.1.1",
         "denque": "^1.1.0",
         "lodash.defaults": "^4.2.0",
         "lodash.flatten": "^4.4.0",
-        "redis-commands": "1.5.0",
+        "redis-commands": "1.6.0",
         "redis-errors": "^1.2.0",
         "redis-parser": "^3.0.0",
         "standard-as-callback": "^2.0.1"
@@ -9808,9 +9808,9 @@
       }
     },
     "redis-commands": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
-      "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.6.0.tgz",
+      "integrity": "sha512-2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ=="
     },
     "redis-errors": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.2.1",
+  "version": "1.2.2-canary.0",
   "description": "A React library to easily integrate and use Split JS SDK",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -58,7 +58,7 @@
   },
   "homepage": "https://github.com/splitio/react-client#readme",
   "dependencies": {
-    "@splitsoftware/splitio": "^10.15.0",
+    "@splitsoftware/splitio": "^10.15.2",
     "shallowequal": "^1.1.0"
   },
   "devDependencies": {

--- a/src/SplitTreatments.tsx
+++ b/src/SplitTreatments.tsx
@@ -40,7 +40,7 @@ class SplitTreatments extends React.Component<ISplitTreatmentsProps> {
             treatments = getControlTreatmentsWithConfig(names);
             if (!client) { this.logWarning = true; }
           }
-          // SplitTreatments only accepts a function as a child, not an React (JSX) Element
+          // SplitTreatments only accepts a function as a child, not a React Element (JSX)
           return children({
             ...splitContext, treatments,
           });

--- a/src/__tests__/SplitTreatments.test.tsx
+++ b/src/__tests__/SplitTreatments.test.tsx
@@ -221,7 +221,7 @@ describe('SplitTreatments', () => {
 
   /**
    * Input validation. Passing invalid split names or attributes while the Sdk
-   * is not ready doesn't emit errors, and log meaningful messages instead.
+   * is not ready doesn't emit errors, and logs meaningful messages instead.
    */
   it('Input validation: invalid "names" and "attributes" props in SplitTreatments.', (done) => {
     const splitNames = ['split1', 'split2'];

--- a/src/__tests__/SplitTreatments.test.tsx
+++ b/src/__tests__/SplitTreatments.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 
 /** Mocks */
 import { mockSdk, Event } from './testUtils/mockSplitSdk';
@@ -217,6 +217,50 @@ describe('SplitTreatments', () => {
       });
     });
 
+  });
+
+  /**
+   * Input validation. Passing invalid split names or attributes while the Sdk
+   * is not ready doesn't emit errors, and log meaningful messages instead.
+   */
+  it('Input validation: invalid "names" and "attributes" props in SplitTreatments.', (done) => {
+    const splitNames = ['split1', 'split2'];
+    const logSpy = jest.spyOn(console, 'log');
+    mount(
+      <SplitFactory config={sdkBrowser} >{
+        ({ factory }) => {
+          return (
+            <>
+              {/* @ts-ignore */}
+              <SplitTreatments split_names={splitNames} >
+                {({ treatments }: ISplitTreatmentsChildProps) => {
+                  expect(treatments).toEqual({});
+                  return null;
+                }}
+              </SplitTreatments>
+              {/* @ts-ignore */}
+              <SplitTreatments names={splitNames[0]} >
+                {({ treatments }: ISplitTreatmentsChildProps) => {
+                  expect(treatments).toEqual({});
+                  return null;
+                }}
+              </SplitTreatments>
+              {/* @ts-ignore */}
+              <SplitTreatments names={[true]} attributes={'invalid'} >
+                {({ treatments }: ISplitTreatmentsChildProps) => {
+                  expect(treatments).toEqual({});
+                  return null;
+                }}
+              </SplitTreatments>
+            </>
+          );
+        }
+      }
+      </SplitFactory>);
+    expect(logSpy).toBeCalledWith('[ERROR] split names must be a non-empty array.');
+    expect(logSpy).toBeCalledWith('[ERROR] you passed an invalid split name, split name must be a non-empty string.');
+
+    done();
   });
 
 });

--- a/src/__tests__/useTreatments.test.tsx
+++ b/src/__tests__/useTreatments.test.tsx
@@ -24,7 +24,7 @@ import useTreatments from '../useTreatments';
 
 describe('useTreatments', () => {
 
-  const splitNames = [ 'split1' ];
+  const splitNames = ['split1'];
   const attributes = { att1: 'att1' };
 
   test('returns the Treatments from the client at Split context updated by SplitFactory.', () => {
@@ -92,6 +92,31 @@ describe('useTreatments', () => {
     );
     expect(getControlTreatmentsWithConfig).toBeCalledWith(splitNames);
     expect(getControlTreatmentsWithConfig).toHaveReturnedWith(treatments);
+  });
+
+  /**
+   * Input validation. Passing invalid split names or attributes while the Sdk
+   * is not ready doesn't emit errors, and log meaningful messages instead.
+   */
+  test('Input validation: invalid "names" and "attributes" params in useTreatments.', (done) => {
+    const logSpy = jest.spyOn(console, 'log');
+
+    mount(
+      React.createElement(
+        () => {
+          // @ts-ignore
+          let treatments = useTreatments('split1');
+          expect(treatments).toEqual({});
+          // @ts-ignore
+          treatments = useTreatments([true]);
+          expect(treatments).toEqual({});
+          return null;
+        }),
+    );
+    expect(logSpy).toBeCalledWith('[ERROR] split names must be a non-empty array.');
+    expect(logSpy).toBeCalledWith('[ERROR] you passed an invalid split name, split name must be a non-empty string.');
+
+    done();
   });
 
 });

--- a/src/__tests__/useTreatments.test.tsx
+++ b/src/__tests__/useTreatments.test.tsx
@@ -96,7 +96,7 @@ describe('useTreatments', () => {
 
   /**
    * Input validation. Passing invalid split names or attributes while the Sdk
-   * is not ready doesn't emit errors, and log meaningful messages instead.
+   * is not ready doesn't emit errors, and logs meaningful messages instead.
    */
   test('Input validation: invalid "names" and "attributes" params in useTreatments.', (done) => {
     const logSpy = jest.spyOn(console, 'log');

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+import { validateSplits } from './utils';
+
 // The string below is a marker and will be replaced by the real version number. DO NOT CHANGE
 export const VERSION: string = 'react-' + 'REACT_SDK_VERSION_NUMBER';
 
@@ -13,8 +15,15 @@ export const CONTROL_WITH_CONFIG: SplitIO.TreatmentWithConfig = {
   config: null,
 };
 
-export const getControlTreatmentsWithConfig = (splitNames: string[]): SplitIO.TreatmentsWithConfig => {
-  return splitNames.reduce((pValue: SplitIO.TreatmentsWithConfig, cValue: string) => {
+export const getControlTreatmentsWithConfig = (splitNames: unknown): SplitIO.TreatmentsWithConfig => {
+  // validate split Names
+  const validatedSplitNames = validateSplits(splitNames);
+
+  // return empty object if the returned value is false
+  if (!validatedSplitNames) return {};
+
+  // return control treatments for each validated split name
+  return validatedSplitNames.reduce((pValue: SplitIO.TreatmentsWithConfig, cValue: string) => {
     pValue[cValue] = CONTROL_WITH_CONFIG;
     return pValue;
   }, {});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,23 +120,6 @@ export function checkHooks(message: string): boolean {
 
 // Input validation utils that will be replaced eventually
 
-/**
- * Removes duplicate items on an array of strings.
- */
-export function uniq(arr: string[]): string[] {
-  const seen: Record<string, boolean> = {};
-  return arr.filter((item) => {
-    return Object.prototype.hasOwnProperty.call(seen, item) ? false : seen[item] = true;
-  });
-}
-
-/**
- * Checks if a given value is a string.
- */
-export function isString(val: unknown): val is string {
-  return typeof val === 'string' || val instanceof String;
-}
-
 export function validateSplits(maybeSplits: unknown, listName = 'split names'): false | string[] {
   if (Array.isArray(maybeSplits) && maybeSplits.length > 0) {
     const validatedArray: string[] = [];
@@ -156,7 +139,7 @@ export function validateSplits(maybeSplits: unknown, listName = 'split names'): 
 
 const TRIMMABLE_SPACES_REGEX = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/;
 
-export function validateSplit(maybeSplit: unknown, item = 'split name'): false | string {
+function validateSplit(maybeSplit: unknown, item = 'split name'): false | string {
   // tslint:disable-next-line: triple-equals
   if (maybeSplit == undefined) {
     console.log(`[ERROR] you passed a null or undefined ${item}, ${item} must be a non-empty string.`);
@@ -176,4 +159,21 @@ export function validateSplit(maybeSplit: unknown, item = 'split name'): false |
   }
 
   return false;
+}
+
+/**
+ * Removes duplicate items on an array of strings.
+ */
+function uniq(arr: string[]): string[] {
+  const seen: Record<string, boolean> = {};
+  return arr.filter((item) => {
+    return Object.prototype.hasOwnProperty.call(seen, item) ? false : seen[item] = true;
+  });
+}
+
+/**
+ * Checks if a given value is a string.
+ */
+function isString(val: unknown): val is string {
+  return typeof val === 'string' || val instanceof String;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -117,3 +117,63 @@ export function checkHooks(message: string): boolean {
     return true;
   }
 }
+
+// Input validation utils that will be replaced eventually
+
+/**
+ * Removes duplicate items on an array of strings.
+ */
+export function uniq(arr: string[]): string[] {
+  const seen: Record<string, boolean> = {};
+  return arr.filter((item) => {
+    return Object.prototype.hasOwnProperty.call(seen, item) ? false : seen[item] = true;
+  });
+}
+
+/**
+ * Checks if a given value is a string.
+ */
+export function isString(val: unknown): val is string {
+  return typeof val === 'string' || val instanceof String;
+}
+
+export function validateSplits(maybeSplits: unknown, listName = 'split names'): false | string[] {
+  if (Array.isArray(maybeSplits) && maybeSplits.length > 0) {
+    const validatedArray: string[] = [];
+    // Remove invalid values
+    maybeSplits.forEach((maybeSplit) => {
+      const splitName = validateSplit(maybeSplit);
+      if (splitName) validatedArray.push(splitName);
+    });
+
+    // Strip off duplicated values if we have valid split names then return
+    if (validatedArray.length) return uniq(validatedArray);
+  }
+
+  console.log(`[ERROR] ${listName} must be a non-empty array.`);
+  return false;
+}
+
+const TRIMMABLE_SPACES_REGEX = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/;
+
+export function validateSplit(maybeSplit: unknown, item = 'split name'): false | string {
+  // tslint:disable-next-line: triple-equals
+  if (maybeSplit == undefined) {
+    console.log(`[ERROR] you passed a null or undefined ${item}, ${item} must be a non-empty string.`);
+  } else if (!isString(maybeSplit)) {
+    console.log(`[ERROR] you passed an invalid ${item}, ${item} must be a non-empty string.`);
+  } else {
+    if (TRIMMABLE_SPACES_REGEX.test(maybeSplit)) {
+      console.log(`[WARN] ${item} "${maybeSplit}" has extra whitespace, trimming.`);
+      maybeSplit = maybeSplit.trim();
+    }
+
+    if ((maybeSplit as string).length > 0) {
+      return maybeSplit as string;
+    } else {
+      console.log(`[ERROR] you passed an empty ${item}, ${item} must be a non-empty string.`);
+    }
+  }
+
+  return false;
+}

--- a/types/constants.d.ts
+++ b/types/constants.d.ts
@@ -3,7 +3,7 @@ export declare const ON: SplitIO.Treatment;
 export declare const OFF: SplitIO.Treatment;
 export declare const CONTROL: SplitIO.Treatment;
 export declare const CONTROL_WITH_CONFIG: SplitIO.TreatmentWithConfig;
-export declare const getControlTreatmentsWithConfig: (splitNames: string[]) => SplitIO.TreatmentsWithConfig;
+export declare const getControlTreatmentsWithConfig: (splitNames: unknown) => SplitIO.TreatmentsWithConfig;
 export declare const WARN_SF_CONFIG_AND_FACTORY: string;
 export declare const ERROR_SF_NO_CONFIG_AND_FACTORY: string;
 export declare const ERROR_SC_NO_FACTORY: string;


### PR DESCRIPTION
# React SDK

## What did you accomplish?

- Updated Javascript Splitio SDK dependency.
- Updated `getControlTreatmentsWithConfig` util, to apply the same input validation over `splitNames` parameter than in `client.getTreatmentsWithConfig` method.

## How do we test the changes introduced in this PR?

- Added new tests in SplitTreatments component and useTreatments hook, to assert that they don't emit errors and log meaningful messages when passing an invalid splitNames parameter.

## Extra Notes