### PR TITLE
Remove SplitTreatments::sCU to avoid stopping render propagation [WIP]

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+1.2.3 (February XX, 2021)
+ - Bugfixing - Removed `shouldComponentUpdate` method of `SplitTreatments` component, to avoid stopping render propagation.
+
 1.2.2 (December 15, 2020)
  - Updated @splitsoftware/splitio dependency to version 10.15.2.
  - Updated internal validation to avoid errors when passing an invalid list of split names to `SplitTreatments` component and `useTreatments` hook.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.2.2",
+  "version": "1.2.3-canary.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1660,12 +1660,6 @@
       "requires": {
         "@types/react": "*"
       }
-    },
-    "@types/shallowequal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/shallowequal/-/shallowequal-1.1.1.tgz",
-      "integrity": "sha512-Lhni3aX80zbpdxRuWhnuYPm8j8UQaa571lHP/xI4W+7BAFhSIhRReXnqjEgT/XzPoXZTJkCqstFMJ8CZTK6IlQ==",
-      "dev": true
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -10323,11 +10317,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.2.2",
+  "version": "1.2.3-canary.0",
   "description": "A React library to easily integrate and use Split JS SDK",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -58,8 +58,7 @@
   },
   "homepage": "https://github.com/splitio/react-client#readme",
   "dependencies": {
-    "@splitsoftware/splitio": "^10.15.2",
-    "shallowequal": "^1.1.0"
+    "@splitsoftware/splitio": "^10.15.2"
   },
   "devDependencies": {
     "@types/enzyme": "^3.10.4",
@@ -69,7 +68,6 @@
     "@types/react": "^16.9.11",
     "@types/react-dom": "^16.9.4",
     "@types/react-test-renderer": "^16.9.1",
-    "@types/shallowequal": "^1.1.1",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "husky": "^3.1.0",

--- a/src/SplitTreatments.tsx
+++ b/src/SplitTreatments.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import shallowEqual from 'shallowequal';
 import SplitContext from './SplitContext';
 import { ISplitTreatmentsProps, ISplitContextValues } from './types';
 import { getControlTreatmentsWithConfig, WARN_ST_NO_CLIENT } from './constants';
@@ -16,14 +15,6 @@ import { getControlTreatmentsWithConfig, WARN_ST_NO_CLIENT } from './constants';
 class SplitTreatments extends React.Component<ISplitTreatmentsProps> {
 
   logWarning?: boolean;
-
-  // The component updates if:
-  // - SplitContext changes, i.e., if the client or status properties tracked by `updateSdk***` props change
-  // - split names or attributes change (shouldComponentUpdate condition)
-  shouldComponentUpdate(nextProps: Readonly<ISplitTreatmentsProps>) {
-    return !shallowEqual(this.props.names, nextProps.names) ||
-      !shallowEqual(this.props.attributes, nextProps.attributes);
-  }
 
   render() {
     const { names, children, attributes } = this.props;

--- a/src/SplitTreatments.tsx
+++ b/src/SplitTreatments.tsx
@@ -7,9 +7,6 @@ import { getControlTreatmentsWithConfig, WARN_ST_NO_CLIENT } from './constants';
  * SplitTreatments accepts a list of split names and optional attributes. It access the client at SplitContext to
  * call 'client.getTreatmentsWithConfig()' method, and passes the returned treatments to a child as a function.
  *
- * Since it is a PureComponent, it does a shallow comparison of props to determine if the component should update,
- * i.e., it uses reference identity for `names` and `attributes` props.
- *
  * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#get-treatments-with-configurations}
  */
 class SplitTreatments extends React.Component<ISplitTreatmentsProps> {

--- a/src/__tests__/SplitTreatments.test.tsx
+++ b/src/__tests__/SplitTreatments.test.tsx
@@ -93,10 +93,10 @@ describe('SplitTreatments', () => {
   });
 
   /**
-   * Tests for shouldComponentUpdate
+   * These tests will change once `SplitTreatments` is updated to compare split names and attributes in order to avoid re-evaluating splits.
    */
 
-  it('does not rerender if names and attributes are the same object.', () => {
+  it('rerenders if names and attributes are the same object.', () => {
     const names = ['split1', 'split2'];
     const attributes = { att1: 'att1' };
     let renderTimes = 0;
@@ -108,10 +108,11 @@ describe('SplitTreatments', () => {
         }}
       </SplitTreatments>);
     wrapper.setProps({ names, attributes });
-    expect(renderTimes).toBe(1);
+    expect(renderTimes).toBe(2);
   });
 
-  it('does not rerender if names and attributes are equals (shallow comparison).', () => {
+  // This test might change if sCU is updated to perform a deep comparison of split names and attributes.
+  it('rerenders if names and attributes are equals (shallow comparison).', () => {
     const names = ['split1', 'split2'];
     const attributes = { att1: 'att1' };
     let renderTimes = 0;
@@ -123,7 +124,7 @@ describe('SplitTreatments', () => {
         }}
       </SplitTreatments>);
     wrapper.setProps({ names: [...names], attributes: { ...attributes } });
-    expect(renderTimes).toBe(1);
+    expect(renderTimes).toBe(2);
   });
 
   it('rerenders if names are not equals (shallow array comparison).', () => {

--- a/types/SplitTreatments.d.ts
+++ b/types/SplitTreatments.d.ts
@@ -4,14 +4,10 @@ import { ISplitTreatmentsProps } from './types';
  * SplitTreatments accepts a list of split names and optional attributes. It access the client at SplitContext to
  * call 'client.getTreatmentsWithConfig()' method, and passes the returned treatments to a child as a function.
  *
- * Since it is a PureComponent, it does a shallow comparison of props to determine if the component should update,
- * i.e., it uses reference identity for `names` and `attributes` props.
- *
  * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#get-treatments-with-configurations}
  */
 declare class SplitTreatments extends React.Component<ISplitTreatmentsProps> {
     logWarning?: boolean;
-    shouldComponentUpdate(nextProps: Readonly<ISplitTreatmentsProps>): boolean;
     render(): JSX.Element;
     componentDidMount(): void;
 }


### PR DESCRIPTION
# React SDK

## What did you accomplish?

- Removed `shouldComponentUpdate` method of `SplitTreatments` component, to avoid stopping render propagation. 

## How do we test the changes introduced in this PR?

- Updated UTs.

## Extra Notes