### PR TITLE
SplitTreatments optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ git:
 
 script:
   - npm test
-  - npm run lint
+  - npm run check
   - BUILD_BRANCH=$TRAVIS_BRANCH BUILD_COMMIT=$TRAVIS_COMMIT npm run build
 
 deploy:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+1.2.3 (February XX, 2021)
+ - Bugfixing - Removed `shouldComponentUpdate` method of `SplitTreatments` component, to avoid stopping render propagation.
+
 1.2.2 (December 15, 2020)
  - Updated @splitsoftware/splitio dependency to version 10.15.2.
  - Updated internal validation to avoid errors when passing an invalid list of split names to `SplitTreatments` component and `useTreatments` hook.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 1.2.3 (February XX, 2021)
- - Bugfixing - Removed `shouldComponentUpdate` method of `SplitTreatments` component, to avoid stopping render propagation.
+ - Bugfixing - Optimizing splits evaluation via memoization in order to remove `shouldComponentUpdate` method of `SplitTreatments` component and avoid stopping render propagation (issue #42).
 
 1.2.2 (December 15, 2020)
  - Updated @splitsoftware/splitio dependency to version 10.15.2.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 1.2.3 (February XX, 2021)
+ - Updated NPM dependencies to include `memoize-one` library.
  - Bugfixing - Optimizing splits evaluation via memoization in order to remove `shouldComponentUpdate` method of `SplitTreatments` component and avoid stopping render propagation (issue #42).
 
 1.2.2 (December 15, 2020)

--- a/CONTRIBUTORS-GUIDE.md
+++ b/CONTRIBUTORS-GUIDE.md
@@ -3,9 +3,9 @@
 Split SDK is an open source project and we welcome feedback and contribution. The information below describes how to build the project with your changes, run the tests, and send the Pull Request(PR).
 
 ## Development
- 
+
 ### Development process
- 
+
 1. Fork the repository and create a topic branch from `development` branch. Please use a descriptive name for your branch.
 2. While developing, use descriptive messages in your commits. Avoid short or meaningless sentences like: "fix bug".
 3. Make sure to add tests for both positive and negative cases.
@@ -20,7 +20,7 @@ Split SDK is an open source project and we welcome feedback and contribution. Th
 
 ### Building the SDK
 
-For widespread use of the SDK with different environments and module formats, we have three different builds: 
+For widespread use of the SDK with different environments and module formats, we have three different builds:
 * A bundled **UMD** file.
 * A **ES2015** modules compatible build.
 * A **CommonJS** modules compatible build.
@@ -35,10 +35,10 @@ For additional testing scripts, refer to our [package.json](package.json) file.
 
 ### Linting and other useful checks
 
-Consider running the linter script (`npm run lint`) and fixing any issues before pushing your changes.
+Consider running the linter script (`npm run check`) and fixing any issues before pushing your changes.
 
 If you want to debug your changes consuming it from a test application, you can use our [app example](./example/react-spa/README.md). You could use symlinks via [npm link command](https://docs.npmjs.com/cli/link.html) and then import the package.
 
 # Contact
- 
+
 If you have any other questions or need to contact us directly in a private manner send us a note at sdks@split.io

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.2.2",
+  "version": "1.2.3-canary.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1660,12 +1660,6 @@
       "requires": {
         "@types/react": "*"
       }
-    },
-    "@types/shallowequal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/shallowequal/-/shallowequal-1.1.1.tgz",
-      "integrity": "sha512-Lhni3aX80zbpdxRuWhnuYPm8j8UQaa571lHP/xI4W+7BAFhSIhRReXnqjEgT/XzPoXZTJkCqstFMJ8CZTK6IlQ==",
-      "dev": true
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -10323,11 +10317,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1661,6 +1661,12 @@
         "@types/react": "*"
       }
     },
+    "@types/shallowequal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/shallowequal/-/shallowequal-1.1.1.tgz",
+      "integrity": "sha512-Lhni3aX80zbpdxRuWhnuYPm8j8UQaa571lHP/xI4W+7BAFhSIhRReXnqjEgT/XzPoXZTJkCqstFMJ8CZTK6IlQ==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -8562,6 +8568,11 @@
         "p-is-promise": "^2.0.0"
       }
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -10317,6 +10328,11 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
   },
   "homepage": "https://github.com/splitio/react-client#readme",
   "dependencies": {
-    "@splitsoftware/splitio": "^10.15.2"
+    "@splitsoftware/splitio": "^10.15.2",
+    "memoize-one": "^5.1.1",
+    "shallowequal": "^1.1.0"
   },
   "devDependencies": {
     "@types/enzyme": "^3.10.4",
@@ -68,6 +70,7 @@
     "@types/react": "^16.9.11",
     "@types/react-dom": "^16.9.4",
     "@types/react-test-renderer": "^16.9.1",
+    "@types/shallowequal": "^1.1.1",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "husky": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build-cjs": "rimraf lib/* types/* && tsc -d true --declarationDir types",
-    "build-esm": "rimraf es/* && tsc -m es2015 -t es6 --outDir es",
-    "build-umd": "rimraf lib-umd/* && webpack --config webpack.dev.js --env.branch=$BUILD_BRANCH --env.commit_hash=$BUILD_COMMIT && webpack --config webpack.prod.js --env.branch=$BUILD_BRANCH --env.commit_hash=$BUILD_COMMIT",
-    "build": "npm run build-cjs && npm run build-esm && npm run build-umd",
+    "build:cjs": "rimraf lib/* types/* && tsc -d true --declarationDir types",
+    "build:esm": "rimraf es/* && tsc -m es2015 -t es6 --outDir es",
+    "build:umd": "rimraf lib-umd/* && webpack --config webpack.dev.js --env.branch=$BUILD_BRANCH --env.commit_hash=$BUILD_COMMIT && webpack --config webpack.prod.js --env.branch=$BUILD_BRANCH --env.commit_hash=$BUILD_COMMIT",
+    "build": "npm run build:cjs && npm run build:esm && npm run build:umd",
     "postbuild": "./version_replace.sh",
     "lint": "tslint -p tsconfig.json 'src/**/*.ts*'",
     "test": "jest",
@@ -28,7 +28,7 @@
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand",
     "publish:rc": "npm publish --tag rc",
     "publish:stable": "npm publish",
-    "prepublishOnly": "npm run build-cjs && npm run build-esm && ./version_replace.sh"
+    "prepublishOnly": "npm run build:cjs && npm run build:esm && ./version_replace.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "build:umd": "rimraf lib-umd/* && webpack --config webpack.dev.js --env.branch=$BUILD_BRANCH --env.commit_hash=$BUILD_COMMIT && webpack --config webpack.prod.js --env.branch=$BUILD_BRANCH --env.commit_hash=$BUILD_COMMIT",
     "build": "npm run build:cjs && npm run build:esm && npm run build:umd",
     "postbuild": "./version_replace.sh",
-    "lint": "tslint -p tsconfig.json 'src/**/*.ts*'",
+    "check": "npm run check:lint && npm run check:types",
+    "check:lint": "tslint -p tsconfig.json 'src/**/*.ts*'",
+    "check:types": "tsc --noEmit",
     "test": "jest",
     "test:watch": "npm test -- --watch",
     "test:coverage": "jest --coverage",
@@ -93,7 +95,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run lint",
+      "pre-commit": "npm run check",
       "pre-push": "npm test && npm run build"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.2.2",
+  "version": "1.2.3-canary.0",
   "description": "A React library to easily integrate and use Split JS SDK",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -58,8 +58,7 @@
   },
   "homepage": "https://github.com/splitio/react-client#readme",
   "dependencies": {
-    "@splitsoftware/splitio": "^10.15.2",
-    "shallowequal": "^1.1.0"
+    "@splitsoftware/splitio": "^10.15.2"
   },
   "devDependencies": {
     "@types/enzyme": "^3.10.4",
@@ -69,7 +68,6 @@
     "@types/react": "^16.9.11",
     "@types/react-dom": "^16.9.4",
     "@types/react-test-renderer": "^16.9.1",
-    "@types/shallowequal": "^1.1.1",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "husky": "^3.1.0",

--- a/src/SplitTreatments.tsx
+++ b/src/SplitTreatments.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import shallowEqual from 'shallowequal';
 import SplitContext from './SplitContext';
 import { ISplitTreatmentsProps, ISplitContextValues } from './types';
 import { getControlTreatmentsWithConfig, WARN_ST_NO_CLIENT } from './constants';
@@ -16,14 +15,6 @@ import { getControlTreatmentsWithConfig, WARN_ST_NO_CLIENT } from './constants';
 class SplitTreatments extends React.Component<ISplitTreatmentsProps> {
 
   logWarning?: boolean;
-
-  // The component updates if:
-  // - SplitContext changes, i.e., if the client or status properties tracked by `updateSdk***` props change
-  // - split names or attributes change (shouldComponentUpdate condition)
-  shouldComponentUpdate(nextProps: Readonly<ISplitTreatmentsProps>) {
-    return !shallowEqual(this.props.names, nextProps.names) ||
-      !shallowEqual(this.props.attributes, nextProps.attributes);
-  }
 
   render() {
     const { names, children, attributes } = this.props;

--- a/src/SplitTreatments.tsx
+++ b/src/SplitTreatments.tsx
@@ -7,9 +7,6 @@ import { getControlTreatmentsWithConfig, WARN_ST_NO_CLIENT } from './constants';
  * SplitTreatments accepts a list of split names and optional attributes. It access the client at SplitContext to
  * call 'client.getTreatmentsWithConfig()' method, and passes the returned treatments to a child as a function.
  *
- * Since it is a PureComponent, it does a shallow comparison of props to determine if the component should update,
- * i.e., it uses reference identity for `names` and `attributes` props.
- *
  * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#get-treatments-with-configurations}
  */
 class SplitTreatments extends React.Component<ISplitTreatmentsProps> {

--- a/src/SplitTreatments.tsx
+++ b/src/SplitTreatments.tsx
@@ -24,9 +24,11 @@ function evaluateSplits(client: SplitIO.IClient, lastUpdate: number, names: Spli
  */
 class SplitTreatments extends React.Component<ISplitTreatmentsProps> {
 
-  logWarning?: boolean;
+  private logWarning?: boolean;
 
-  evaluateSplits = memoizeOne(evaluateSplits, argsAreEqual);
+  // Attaching a memoized `client.getTreatmentsWithConfig` function to the component instance, to avoid duplicated impressions because
+  // the function result is the same given the same `client` instance, `lastUpdate` timestamp, and list of split `names` and `attributes`.
+  private evaluateSplits = memoizeOne(evaluateSplits, argsAreEqual);
 
   render() {
     const { names, children, attributes } = this.props;

--- a/src/__tests__/SplitTreatments.test.tsx
+++ b/src/__tests__/SplitTreatments.test.tsx
@@ -93,10 +93,10 @@ describe('SplitTreatments', () => {
   });
 
   /**
-   * Tests for shouldComponentUpdate
+   * These tests will change once `SplitTreatments` is updated to compare split names and attributes in order to avoid re-evaluating splits.
    */
 
-  it('does not rerender if names and attributes are the same object.', () => {
+  it('rerenders if names and attributes are the same object.', () => {
     const names = ['split1', 'split2'];
     const attributes = { att1: 'att1' };
     let renderTimes = 0;
@@ -108,10 +108,11 @@ describe('SplitTreatments', () => {
         }}
       </SplitTreatments>);
     wrapper.setProps({ names, attributes });
-    expect(renderTimes).toBe(1);
+    expect(renderTimes).toBe(2);
   });
 
-  it('does not rerender if names and attributes are equals (shallow comparison).', () => {
+  // This test might change if sCU is updated to perform a deep comparison of split names and attributes.
+  it('rerenders if names and attributes are equals (shallow comparison).', () => {
     const names = ['split1', 'split2'];
     const attributes = { att1: 'att1' };
     let renderTimes = 0;
@@ -123,7 +124,7 @@ describe('SplitTreatments', () => {
         }}
       </SplitTreatments>);
     wrapper.setProps({ names: [...names], attributes: { ...attributes } });
-    expect(renderTimes).toBe(1);
+    expect(renderTimes).toBe(2);
   });
 
   it('rerenders if names are not equals (shallow array comparison).', () => {

--- a/src/__tests__/testUtils/mockSplitSdk.ts
+++ b/src/__tests__/testUtils/mockSplitSdk.ts
@@ -95,6 +95,11 @@ function mockClient(key: SplitIO.SplitKey, trafficType?: string) {
     __internalListenersCount__,
     // Factory context exposed to get client readiness status (READY, READY_FROM_CACHE, HAS_TIMEDOUT, DESTROYED)
     __context: context,
+    // Restore the mock client to its initial NO-READY status.
+    // Useful when you want to reuse the same mock between tests after emitting events or destroying the instance.
+    __restore() {
+      __isReady__ = __isReadyFromCache__ = __hasTimedout__ = __isDestroyed__ = undefined;
+    }
   });
 }
 

--- a/types/SplitTreatments.d.ts
+++ b/types/SplitTreatments.d.ts
@@ -4,14 +4,10 @@ import { ISplitTreatmentsProps } from './types';
  * SplitTreatments accepts a list of split names and optional attributes. It access the client at SplitContext to
  * call 'client.getTreatmentsWithConfig()' method, and passes the returned treatments to a child as a function.
  *
- * Since it is a PureComponent, it does a shallow comparison of props to determine if the component should update,
- * i.e., it uses reference identity for `names` and `attributes` props.
- *
  * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#get-treatments-with-configurations}
  */
 declare class SplitTreatments extends React.Component<ISplitTreatmentsProps> {
     logWarning?: boolean;
-    shouldComponentUpdate(nextProps: Readonly<ISplitTreatmentsProps>): boolean;
     render(): JSX.Element;
     componentDidMount(): void;
 }

--- a/types/SplitTreatments.d.ts
+++ b/types/SplitTreatments.d.ts
@@ -7,7 +7,8 @@ import { ISplitTreatmentsProps } from './types';
  * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#get-treatments-with-configurations}
  */
 declare class SplitTreatments extends React.Component<ISplitTreatmentsProps> {
-    logWarning?: boolean;
+    private logWarning?;
+    private evaluateSplits;
     render(): JSX.Element;
     componentDidMount(): void;
 }


### PR DESCRIPTION
# React SDK

## What did you accomplish?

- Removed shouldComponentUpdate method of SplitTreatments component, to avoid stopping render propagation.
- Using a memoized function to call `client.getTreatmentsWithConfig`, instead of overwriting sCU method. 
- Updated some script names in package.json for consistency.

## How do we test the changes introduced in this PR?

- Updated and added new tests.

## Extra Notes