### PR TITLE
Added support for React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "webpack-merge": "^4.2.2"
   },
   "peerDependencies": {
-    "react": "^16.3.0"
+    "react": "^16.3.0 || ^17.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
# React SDK

## What did you accomplish?

Currently, the project specifies a dependency on React version `^16.3.0`, which means installing it in a React 17 project will cause the error below. Upgraded the package dependencies to allow both >16.3 and 17 versions of React.

```
While resolving: project@1.5.0
Found: react@17.0.1
node_modules/react
   react@"^17.0.1" from the root project

Could not resolve dependency:
peer react@"^16.3.0" from @splitsoftware/splitio-react@1.2.3-canary.1
node_modules/@splitsoftware/splitio-react
   @splitsoftware/splitio-react@"^1.2.3-canary.1" from the root project
```