### PR TITLE
Update internal SDK listeners to avoid some wrong log messages

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+1.2.6 (XXX XX, 2021)
+ - Updated event listeners to avoid some misleading error logs.
+
 1.2.5 (April 29, 2021)
  - Updated some NPM dependencies mostly for vulnerability fixes.
  - Updated Split's SDK package for vulnerability fixes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.2.5",
+  "version": "1.2.6-canary.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.2.5",
+  "version": "1.2.6-canary.0",
   "description": "A React library to easily integrate and use Split JS SDK",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/SplitClient.tsx
+++ b/src/SplitClient.tsx
@@ -64,9 +64,10 @@ export class SplitComponent extends React.Component<IUpdateProps & { factory: Sp
   // The listeners take into account the value of `updateOnSdk***` props.
   subscribeToEvents(client: SplitIO.IClient | null) {
     if (client) {
-      client.once(client.Event.SDK_READY, this.setReady);
-      client.once(client.Event.SDK_READY_FROM_CACHE, this.setReadyFromCache);
-      client.once(client.Event.SDK_READY_TIMED_OUT, this.setTimedout);
+      const status = getStatus(client);
+      if (!status.isReady) client.once(client.Event.SDK_READY, this.setReady);
+      if (!status.isReadyFromCache) client.once(client.Event.SDK_READY_FROM_CACHE, this.setReadyFromCache);
+      if (!status.hasTimedout && !status.isReady) client.once(client.Event.SDK_READY_TIMED_OUT, this.setTimedout);
       client.on(client.Event.SDK_UPDATE, this.setUpdate);
     }
   }

--- a/src/__tests__/SplitFactory.test.tsx
+++ b/src/__tests__/SplitFactory.test.tsx
@@ -8,6 +8,7 @@ jest.mock('@splitsoftware/splitio', () => {
 });
 import { SplitFactory as SplitSdk } from '@splitsoftware/splitio';
 import { sdkBrowser } from './testUtils/sdkConfigs';
+const logSpy = jest.spyOn(console, 'log');
 
 /** Test target */
 import { ISplitFactoryChildProps } from '../types';
@@ -235,7 +236,6 @@ describe('SplitFactory', () => {
   });
 
   test('logs warning if both a config and factory are passed as props.', () => {
-    const logSpy = jest.spyOn(console, 'log');
     const outerFactory = SplitSdk(sdkBrowser);
 
     shallow(
@@ -247,6 +247,7 @@ describe('SplitFactory', () => {
       </SplitFactory>);
 
     expect(logSpy).toBeCalledWith(WARN_SF_CONFIG_AND_FACTORY);
+    logSpy.mockRestore();
   });
 
   test('logs error and passes null factory if rendered without a Split config and factory.', () => {

--- a/src/__tests__/SplitTreatments.test.tsx
+++ b/src/__tests__/SplitTreatments.test.tsx
@@ -8,6 +8,7 @@ jest.mock('@splitsoftware/splitio', () => {
 });
 import { SplitFactory as SplitSdk } from '@splitsoftware/splitio';
 import { sdkBrowser } from './testUtils/sdkConfigs';
+const logSpy = jest.spyOn(console, 'log');
 
 /** Test target */
 import { ISplitTreatmentsChildProps, ISplitTreatmentsProps, ISplitClientProps } from '../types';
@@ -25,6 +26,8 @@ import { getControlTreatmentsWithConfig, WARN_ST_NO_CLIENT } from '../constants'
 import { getIsReady } from '../utils';
 
 describe('SplitTreatments', () => {
+
+  afterEach(() => { logSpy.mockClear() });
 
   it('passes as treatments prop the value returned by the function "getControlTreatmentsWithConfig" if the SDK is not ready.', (done) => {
     const splitNames = ['split1', 'split2'];
@@ -78,7 +81,6 @@ describe('SplitTreatments', () => {
 
   it('logs error and passes control treatments ("getControlTreatmentsWithConfig") if rendered outside an SplitProvider component.', () => {
     const splitNames = ['split1', 'split2'];
-    const logSpy = jest.spyOn(console, 'log');
     let passedTreatments;
     mount(
       <SplitTreatments names={splitNames} >
@@ -98,7 +100,7 @@ describe('SplitTreatments', () => {
    */
   it('Input validation: invalid "names" and "attributes" props in SplitTreatments.', (done) => {
     const splitNames = ['split1', 'split2'];
-    const logSpy = jest.spyOn(console, 'log');
+
     mount(
       <SplitFactory config={sdkBrowser} >{
         ({ factory }) => {

--- a/src/__tests__/testUtils/mockSplitSdk.ts
+++ b/src/__tests__/testUtils/mockSplitSdk.ts
@@ -152,7 +152,6 @@ function assertNoListenersOnClient(client: any) {
   expect(client.__emitter__.listenerCount(Event.SDK_UPDATE)).toBe(client.__internalListenersCount__[Event.SDK_UPDATE]);
 }
 
-export function clientListenerCount(client: any, event: string): number {
-  debugger;
+export function clientListenerCount(client: any, event: string) {
   return client.__emitter__.listenerCount(event) - client.__internalListenersCount__[event];
 }

--- a/src/__tests__/testUtils/mockSplitSdk.ts
+++ b/src/__tests__/testUtils/mockSplitSdk.ts
@@ -151,3 +151,8 @@ function assertNoListenersOnClient(client: any) {
   expect(client.__emitter__.listenerCount(Event.SDK_READY_TIMED_OUT)).toBe(client.__internalListenersCount__[Event.SDK_READY_TIMED_OUT]);
   expect(client.__emitter__.listenerCount(Event.SDK_UPDATE)).toBe(client.__internalListenersCount__[Event.SDK_UPDATE]);
 }
+
+export function clientListenerCount(client: any, event: string): number {
+  debugger;
+  return client.__emitter__.listenerCount(event) - client.__internalListenersCount__[event];
+}

--- a/src/__tests__/useTreatments.test.tsx
+++ b/src/__tests__/useTreatments.test.tsx
@@ -16,6 +16,7 @@ jest.mock('../constants', () => {
   };
 });
 import { getControlTreatmentsWithConfig } from '../constants';
+const logSpy = jest.spyOn(console, 'log');
 
 /** Test target */
 import SplitFactory from '../SplitFactory';
@@ -99,8 +100,6 @@ describe('useTreatments', () => {
    * is not ready doesn't emit errors, and logs meaningful messages instead.
    */
   test('Input validation: invalid "names" and "attributes" params in useTreatments.', (done) => {
-    const logSpy = jest.spyOn(console, 'log');
-
     mount(
       React.createElement(
         () => {


### PR DESCRIPTION
# React SDK

## What did you accomplish?

- Updated internal SplitComponent to not add event listeners for those SDK events that has been already emitted, to avoid the confusing log message `A listener was added for SDK_READY/SDK_READY_TIMED_OUT' on the SDK, which has already fired and won't be emitted again.`.

## How do we test the changes introduced in this PR?

- Added asserts in UTs to check that event listeners are only attached if needed.

## Extra Notes