### PR TITLE
Update useTreatments hooks and upgrade JS SDK to include telemetry v2 and bug fixes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -39,14 +39,14 @@ jobs:
         run: BUILD_BRANCH=$(echo "${GITHUB_REF#refs/heads/}") BUILD_COMMIT=${{ github.sha }} npm run build
 
       - name: Configure AWS credentials (development)
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/useTreatments_fix' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/development' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::079419646996:role/public-assets
           aws-region: us-east-1
 
       - name: Upload to S3 (development)
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/useTreatments_fix' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/development' }}
         run: aws s3 sync $SOURCE_DIR s3://$BUCKET/$DEST_DIR $ARGS
         env:
           BUCKET: split-public-stage

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -39,14 +39,14 @@ jobs:
         run: BUILD_BRANCH=$(echo "${GITHUB_REF#refs/heads/}") BUILD_COMMIT=${{ github.sha }} npm run build
 
       - name: Configure AWS credentials (development)
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/development' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/useTreatments_fix' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::079419646996:role/public-assets
           aws-region: us-east-1
 
       - name: Upload to S3 (development)
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/development' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/useTreatments_fix' }}
         run: aws s3 sync $SOURCE_DIR s3://$BUCKET/$DEST_DIR $ARGS
         env:
           BUCKET: split-public-stage

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+1.4.2 (June XXX, 2022)
+ - Bugfixing - Fixed issue with useTreatments hooks, to return control treatment without evaluating splits when the SDK client is not ready for evaluation or destroyed, to avoid control impressions.
+
 1.4.1 (May 11, 2022)
  - Updated React peer dependency range to include React@18.x.x.
  - Updated @splitsoftware/splitio dependency to version 10.18.2, which includes some vulnerability fixes.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 1.4.2 (June XXX, 2022)
- - Bugfixing - Fixed issue with useTreatments hooks, to return control treatment without evaluating splits when the SDK client is not ready for evaluation or destroyed, to avoid control impressions.
+ - Bugfixing - Fixed issue with useTreatments hooks, to return control treatments without evaluating splits when the SDK client is not ready or is destroyed, to avoid not ready impressions and warning log.
+ - Bugfixing - Updated submitters logic, to avoid dropping impressions and events that are being tracked while POST request is pending.
 
 1.4.1 (May 11, 2022)
  - Updated React peer dependency range to include React@18.x.x.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,7 +3,7 @@
  - Updated @splitsoftware/splitio dependency to version 10.19.1, which includes:
       - Added `scheduler.telemetryRefreshRate` property to SDK configuration, and deprecated `scheduler.metricsRefreshRate` property.
       - Updated SDK telemetry storage, metrics and updater to be more effective and send less often.
-      - Updated eventsource dependecy range to ^1.1.2 to avoid dependency resolution to a vulnerable version of this package as much as possible when combined with other dependencies.
+      - Updated eventsource dependency range to ^1.1.2 to avoid a vulnerability and dependency resolution to a vulnerable version of url-parse transitive dependency.
       - Bugfixing - Updated submitters logic, to avoid dropping impressions and events that are being tracked while POST request is pending.
 
 1.4.1 (May 11, 2022)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 1.4.2 (June XXX, 2022)
  - Bugfixing - Fixed issue with useTreatments hooks, to return control treatments without evaluating splits when the SDK client is not ready or is destroyed, to avoid not ready impressions and warning log.
- - Bugfixing - Updated submitters logic, to avoid dropping impressions and events that are being tracked while POST request is pending.
+ - Updated @splitsoftware/splitio dependency to version 10.19.1, which includes:
+      - Added `scheduler.telemetryRefreshRate` property to SDK configuration, and deprecated `scheduler.metricsRefreshRate` property.
+      - Updated SDK telemetry storage, metrics and updater to be more effective and send less often.
+      - Updated eventsource dependecy range to ^1.1.2 to avoid dependency resolution to a vulnerable version of this package as much as possible when combined with other dependencies.
+      - Bugfixing - Updated submitters logic, to avoid dropping impressions and events that are being tracked while POST request is pending.
 
 1.4.1 (May 11, 2022)
  - Updated React peer dependency range to include React@18.x.x.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-1.4.2 (June XXX, 2022)
+1.5.0 (June 13, 2022)
  - Bugfixing - Fixed issue with useTreatments hooks, to return control treatments without evaluating splits when the SDK client is not ready or is destroyed, to avoid not ready impressions and warning log.
  - Updated @splitsoftware/splitio dependency to version 10.19.1, which includes:
       - Added `scheduler.telemetryRefreshRate` property to SDK configuration, and deprecated `scheduler.metricsRefreshRate` property.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.4.2-rc.1",
+  "version": "1.4.2-rc.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1253,12 +1253,12 @@
       }
     },
     "@splitsoftware/splitio": {
-      "version": "10.19.1-rc3",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-10.19.1-rc3.tgz",
-      "integrity": "sha512-D0h0i8PTR0EMJ8ANSjIXA9TTi9ppDkzo37y97cmgT0h6Jk0sJmuXZ/PZpMqLqG5L7i/3AGiEAgZc0i9qqtKQrQ==",
+      "version": "10.19.1-rc.4",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-10.19.1-rc.4.tgz",
+      "integrity": "sha512-0Sv9araYK9fg+Iqp5eW3v03GwNJb2hFwoyS/zE37zbTWCe2hQf/oPBLwJn7r2VOJpkHd0rNFJugPSZhiUd0OYg==",
       "dev": true,
       "requires": {
-        "@splitsoftware/splitio-commons": "1.4.1-rc.1",
+        "@splitsoftware/splitio-commons": "1.4.1-rc.2",
         "@types/google.analytics": "0.0.40",
         "@types/ioredis": "^4.28.0",
         "eventsource": "^1.1.2",
@@ -1269,9 +1269,9 @@
       }
     },
     "@splitsoftware/splitio-commons": {
-      "version": "1.4.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.4.1-rc.1.tgz",
-      "integrity": "sha512-7VmbXUIs/plghS1phZKpy2mGpyBJ/yBqim/y26WioqUXs1/GnFqRwR2+qV0i3EYegdMocfyQTOKa1WGGx0xc9g==",
+      "version": "1.4.1-rc.2",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.4.1-rc.2.tgz",
+      "integrity": "sha512-btXzK6o6XmhdVkT4Mymnvq9Kj9Gci6hwLRZkRXNZKeWQ5BfCCr2ilFd3+Fea3prwVpO9/x/QGzcTjxS2zKqsZw==",
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -6051,13 +6051,13 @@
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
           "dev": true
         },
         "whatwg-url": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
           "dev": true,
           "requires": {
             "tr46": "~0.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1253,25 +1253,36 @@
       }
     },
     "@splitsoftware/splitio": {
-      "version": "10.18.2",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-10.18.2.tgz",
-      "integrity": "sha512-nl2Jlq6EOgoDWZnPMcWcE/jURRPbr+2dfX32Gh4pfTRTSUHS2qJ889xwXqp2yt1AXcGXnyyZO5/U7AoeL1wtiQ==",
+      "version": "10.19.1-rc2",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-10.19.1-rc2.tgz",
+      "integrity": "sha512-rMiuu6VQTfwbQ9qcPAQd7NesM/sl6rWrm5UmQZrG09cOGF4+85QDZU5/iawLcNnOuS3FawjyPF7ZndMh7pyB7A==",
       "dev": true,
       "requires": {
-        "@splitsoftware/splitio-commons": "1.3.1",
+        "@splitsoftware/splitio-commons": "1.4.1-rc.0",
         "@types/google.analytics": "0.0.40",
         "@types/ioredis": "^4.28.0",
-        "eventsource": "^1.0.7",
+        "eventsource": "^1.1.2",
         "ioredis": "^4.28.0",
         "js-yaml": "3.13.1",
         "node-fetch": "^2.6.7",
         "unfetch": "^4.2.0"
+      },
+      "dependencies": {
+        "@splitsoftware/splitio-commons": {
+          "version": "1.4.1-rc.0",
+          "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.4.1-rc.0.tgz",
+          "integrity": "sha512-pKYyDAfpvu66rDDXN2EIu3hWqwiScwjfIaysc7g845c0YI9YMoDZxtcDYObM9tTM8C4eLG+wgXRg8K6OIRVcwg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@splitsoftware/splitio-commons": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.3.1.tgz",
-      "integrity": "sha512-otHrBCNJ2BP2tby31juRFfBETYzBVJZVecg1d27o9v5IKsv9uhzF9Q8B35GPpbndFht/596O2OlxKH5HdbjBwQ==",
+      "version": "1.4.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.4.1-rc.1.tgz",
+      "integrity": "sha512-7VmbXUIs/plghS1phZKpy2mGpyBJ/yBqim/y26WioqUXs1/GnFqRwR2+qV0i3EYegdMocfyQTOKa1WGGx0xc9g==",
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -2828,14 +2839,11 @@
       "dev": true
     },
     "eventsource": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.1.tgz",
-      "integrity": "sha512-qV5ZC0h7jYIAOhArFJgSfdyz6rALJyb270714o7ZtNnw2WSJ+eexhKtE0O8LYPRsHZHf2osHKZBxGPvm3kPkCA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.2.tgz",
+      "integrity": "sha512-xAH3zWhgO2/3KIniEKYPr8plNSzlGINOUqYj0m0u7AB81iRw8b/3E73W6AuU+6klLbaSFmZnaETQ2lXPfAydrA==",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "original": "^1.0.0"
-      }
+      "optional": true
     },
     "execa": {
       "version": "1.0.0",
@@ -5822,7 +5830,7 @@
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true
     },
     "lodash.escape": {
@@ -5834,7 +5842,7 @@
     "lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true
     },
     "lodash.flattendeep": {
@@ -5846,7 +5854,7 @@
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "dev": true
     },
     "lodash.isequal": {
@@ -6048,7 +6056,7 @@
         "tr46": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
           "dev": true
         },
         "webidl-conversions": {
@@ -6237,16 +6245,6 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
         "word-wrap": "~1.2.3"
-      }
-    },
-    "original": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
-      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "url-parse": "^1.4.3"
       }
     },
     "p-each-series": {
@@ -6477,13 +6475,6 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
-    "querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true,
-      "optional": true
-    },
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -6603,13 +6594,13 @@
     "redis-errors": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
       "dev": true
     },
     "redis-parser": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
       "dev": true,
       "requires": {
         "redis-errors": "^1.0.0"
@@ -6720,13 +6711,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true,
-      "optional": true
     },
     "resolve": {
       "version": "1.12.0",
@@ -7463,17 +7447,6 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "util-deprecate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.4.2-rc.2",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1253,12 +1253,12 @@
       }
     },
     "@splitsoftware/splitio": {
-      "version": "10.19.1-rc.4",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-10.19.1-rc.4.tgz",
-      "integrity": "sha512-0Sv9araYK9fg+Iqp5eW3v03GwNJb2hFwoyS/zE37zbTWCe2hQf/oPBLwJn7r2VOJpkHd0rNFJugPSZhiUd0OYg==",
+      "version": "10.19.1",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-10.19.1.tgz",
+      "integrity": "sha512-iAf0UL3ZMZMxfqgrhpigaWx893uM4qmj72P5sOVq66lZhJBXDQJSijaozxCoxC+/QM4wYYRePV2meJn1q5fD+g==",
       "dev": true,
       "requires": {
-        "@splitsoftware/splitio-commons": "1.4.1-rc.2",
+        "@splitsoftware/splitio-commons": "1.4.1",
         "@types/google.analytics": "0.0.40",
         "@types/ioredis": "^4.28.0",
         "eventsource": "^1.1.2",
@@ -1269,9 +1269,9 @@
       }
     },
     "@splitsoftware/splitio-commons": {
-      "version": "1.4.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.4.1-rc.2.tgz",
-      "integrity": "sha512-btXzK6o6XmhdVkT4Mymnvq9Kj9Gci6hwLRZkRXNZKeWQ5BfCCr2ilFd3+Fea3prwVpO9/x/QGzcTjxS2zKqsZw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.4.1.tgz",
+      "integrity": "sha512-ukgiyi8Ga3wW0jiwVLMadgcShmqWO/IiQFDkoKIBkUF3H7ri9/deShJWHBMVldpLD+uLbgmzOPXwO8okwQqyKA==",
       "requires": {
         "tslib": "^2.3.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.4.2-rc.0",
+  "version": "1.4.2-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1253,12 +1253,12 @@
       }
     },
     "@splitsoftware/splitio": {
-      "version": "10.19.1-rc2",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-10.19.1-rc2.tgz",
-      "integrity": "sha512-rMiuu6VQTfwbQ9qcPAQd7NesM/sl6rWrm5UmQZrG09cOGF4+85QDZU5/iawLcNnOuS3FawjyPF7ZndMh7pyB7A==",
+      "version": "10.19.1-rc3",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-10.19.1-rc3.tgz",
+      "integrity": "sha512-D0h0i8PTR0EMJ8ANSjIXA9TTi9ppDkzo37y97cmgT0h6Jk0sJmuXZ/PZpMqLqG5L7i/3AGiEAgZc0i9qqtKQrQ==",
       "dev": true,
       "requires": {
-        "@splitsoftware/splitio-commons": "1.4.1-rc.0",
+        "@splitsoftware/splitio-commons": "1.4.1-rc.1",
         "@types/google.analytics": "0.0.40",
         "@types/ioredis": "^4.28.0",
         "eventsource": "^1.1.2",
@@ -1266,17 +1266,6 @@
         "js-yaml": "3.13.1",
         "node-fetch": "^2.6.7",
         "unfetch": "^4.2.0"
-      },
-      "dependencies": {
-        "@splitsoftware/splitio-commons": {
-          "version": "1.4.1-rc.0",
-          "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.4.1-rc.0.tgz",
-          "integrity": "sha512-pKYyDAfpvu66rDDXN2EIu3hWqwiScwjfIaysc7g845c0YI9YMoDZxtcDYObM9tTM8C4eLG+wgXRg8K6OIRVcwg==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@splitsoftware/splitio-commons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.4.1",
+  "version": "1.4.2-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2832,6 +2832,7 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.1.tgz",
       "integrity": "sha512-qV5ZC0h7jYIAOhArFJgSfdyz6rALJyb270714o7ZtNnw2WSJ+eexhKtE0O8LYPRsHZHf2osHKZBxGPvm3kPkCA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "original": "^1.0.0"
       }
@@ -6243,6 +6244,7 @@
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
       "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "url-parse": "^1.4.3"
       }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "homepage": "https://github.com/splitio/react-client#readme",
   "dependencies": {
-    "@splitsoftware/splitio-commons": "1.3.1",
+    "@splitsoftware/splitio-commons": "1.4.1-rc.1",
     "@types/google.analytics": "0.0.40",
     "@types/ioredis": "^4.28.0",
     "memoize-one": "^5.1.1",
@@ -69,7 +69,7 @@
     "unfetch": "^4.2.0"
   },
   "devDependencies": {
-    "@splitsoftware/splitio": "10.18.2",
+    "@splitsoftware/splitio": "10.19.1-rc2",
     "@types/enzyme": "^3.10.4",
     "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/events": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.4.1",
+  "version": "1.4.2-rc.0",
   "description": "A React library to easily integrate and use Split JS SDK",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.4.2-rc.0",
+  "version": "1.4.2-rc.1",
   "description": "A React library to easily integrate and use Split JS SDK",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -69,7 +69,7 @@
     "unfetch": "^4.2.0"
   },
   "devDependencies": {
-    "@splitsoftware/splitio": "10.19.1-rc2",
+    "@splitsoftware/splitio": "10.19.1-rc3",
     "@types/enzyme": "^3.10.4",
     "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/events": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.4.2-rc.2",
+  "version": "1.5.0",
   "description": "A React library to easily integrate and use Split JS SDK",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -61,7 +61,7 @@
   },
   "homepage": "https://github.com/splitio/react-client#readme",
   "dependencies": {
-    "@splitsoftware/splitio-commons": "1.4.1-rc.2",
+    "@splitsoftware/splitio-commons": "1.4.1",
     "@types/google.analytics": "0.0.40",
     "@types/ioredis": "^4.28.0",
     "memoize-one": "^5.1.1",
@@ -69,7 +69,7 @@
     "unfetch": "^4.2.0"
   },
   "devDependencies": {
-    "@splitsoftware/splitio": "10.19.1-rc.4",
+    "@splitsoftware/splitio": "10.19.1",
     "@types/enzyme": "^3.10.4",
     "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/events": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.4.2-rc.1",
+  "version": "1.4.2-rc.2",
   "description": "A React library to easily integrate and use Split JS SDK",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -61,7 +61,7 @@
   },
   "homepage": "https://github.com/splitio/react-client#readme",
   "dependencies": {
-    "@splitsoftware/splitio-commons": "1.4.1-rc.1",
+    "@splitsoftware/splitio-commons": "1.4.1-rc.2",
     "@types/google.analytics": "0.0.40",
     "@types/ioredis": "^4.28.0",
     "memoize-one": "^5.1.1",
@@ -69,7 +69,7 @@
     "unfetch": "^4.2.0"
   },
   "devDependencies": {
-    "@splitsoftware/splitio": "10.19.1-rc3",
+    "@splitsoftware/splitio": "10.19.1-rc.4",
     "@types/enzyme": "^3.10.4",
     "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/events": "^3.0.0",

--- a/src/__tests__/useTreatments.test.tsx
+++ b/src/__tests__/useTreatments.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 /** Mocks */
-import { mockSdk } from './testUtils/mockSplitSdk';
+import { mockSdk, Event } from './testUtils/mockSplitSdk';
 jest.mock('@splitsoftware/splitio', () => {
   return { SplitFactory: mockSdk() };
 });
@@ -15,7 +15,7 @@ jest.mock('../constants', () => {
     getControlTreatmentsWithConfig: jest.fn(actual.getControlTreatmentsWithConfig),
   };
 });
-import { getControlTreatmentsWithConfig } from '../constants';
+import { CONTROL_WITH_CONFIG, getControlTreatmentsWithConfig } from '../constants';
 const logSpy = jest.spyOn(console, 'log');
 
 /** Test target */
@@ -28,24 +28,32 @@ describe('useTreatments', () => {
   const splitNames = ['split1'];
   const attributes = { att1: 'att1' };
 
-  test('returns the Treatments from the client at Split context updated by SplitFactory.', () => {
+  test('returns the treatments evaluated by the client at Split context updated by SplitFactory, or control if the client is not operational.', () => {
     const outerFactory = SplitSdk(sdkBrowser);
+    const client: any = outerFactory.client();
     let treatments;
 
-    mount(
+    const wrapper = mount(
       <SplitFactory factory={outerFactory} >{
         React.createElement(() => {
           treatments = useTreatments(splitNames, attributes);
           return null;
         })}</SplitFactory>,
     );
-    const getTreatmentsWithConfig: jest.Mock = (outerFactory.client() as any).getTreatmentsWithConfig;
-    expect(getTreatmentsWithConfig).toBeCalledWith(splitNames, attributes);
-    expect(getTreatmentsWithConfig).toHaveReturnedWith(treatments);
+
+    // returns control treatment if not operational (SDK not ready or destroyed), without calling `getTreatmentsWithConfig` method
+    expect(client.getTreatmentsWithConfig).not.toBeCalled();
+    expect(treatments).toEqual({ split1: CONTROL_WITH_CONFIG });
+
+    // once operational (SDK_READY), it evaluates splits
+    client.__emitter__.emit(Event.SDK_READY);
+    expect(client.getTreatmentsWithConfig).toBeCalledWith(splitNames, attributes);
+    expect(client.getTreatmentsWithConfig).toHaveReturnedWith(treatments);
   });
 
-  test('returns the Treatments from the client at Split context updated by SplitClient.', () => {
+  test('returns the Treatments from the client at Split context updated by SplitClient, or control if the client is not operational.', () => {
     const outerFactory = SplitSdk(sdkBrowser);
+    const client: any = outerFactory.client('user2');
     let treatments;
 
     mount(
@@ -58,14 +66,24 @@ describe('useTreatments', () => {
         </SplitClient>
       </SplitFactory>,
     );
-    const getTreatmentsWithConfig: jest.Mock = (outerFactory.client('user2') as any).getTreatmentsWithConfig;
-    expect(getTreatmentsWithConfig).toBeCalledWith(splitNames, attributes);
-    expect(getTreatmentsWithConfig).toHaveReturnedWith(treatments);
+
+    // returns control treatment if not operational (SDK not ready or destroyed), without calling `getTreatmentsWithConfig` method
+    expect(client.getTreatmentsWithConfig).not.toBeCalled();
+    expect(treatments).toEqual({ split1: CONTROL_WITH_CONFIG });
+
+    // once operational (SDK_READY_FROM_CACHE), it evaluates splits
+    client.__emitter__.emit(Event.SDK_READY_FROM_CACHE);
+    expect(client.getTreatmentsWithConfig).toBeCalledWith(splitNames, attributes);
+    expect(client.getTreatmentsWithConfig).toHaveReturnedWith(treatments);
   });
 
-  test('returns the Treatments from a new client given a splitKey.', () => {
+  test('returns the Treatments from a new client given a splitKey, or control if the client is not operational.', async () => {
     const outerFactory = SplitSdk(sdkBrowser);
+    const client: any = outerFactory.client('user2');
     let treatments;
+
+    client.__emitter__.emit(Event.SDK_READY);
+    await client.destroy();
 
     mount(
       <SplitFactory factory={outerFactory} >{
@@ -75,9 +93,10 @@ describe('useTreatments', () => {
         })}
       </SplitFactory>,
     );
-    const getTreatmentsWithConfig: jest.Mock = (outerFactory.client('user2') as any).getTreatmentsWithConfig;
-    expect(getTreatmentsWithConfig).toBeCalledWith(splitNames, attributes);
-    expect(getTreatmentsWithConfig).toHaveReturnedWith(treatments);
+
+    // returns control treatment if not operational (SDK not ready or destroyed), without calling `getTreatmentsWithConfig` method
+    expect(client.getTreatmentsWithConfig).not.toBeCalled();
+    expect(treatments).toEqual({ split1: CONTROL_WITH_CONFIG });
   });
 
   // THE FOLLOWING TEST WILL PROBABLE BE CHANGED BY 'return a null value or throw an error if it is not inside an SplitProvider'

--- a/src/useTreatments.ts
+++ b/src/useTreatments.ts
@@ -1,6 +1,6 @@
 import useClient from './useClient';
 import { getControlTreatmentsWithConfig, ERROR_UT_NO_USECONTEXT } from './constants';
-import { checkHooks } from './utils';
+import { checkHooks, IClientWithContext } from './utils';
 
 /**
  * 'useTreatments' is a custom hook that returns a list of treatments.
@@ -12,7 +12,7 @@ import { checkHooks } from './utils';
  */
 const useTreatments = (splitNames: string[], attributes?: SplitIO.Attributes, key?: SplitIO.SplitKey): SplitIO.TreatmentsWithConfig => {
   const client = checkHooks(ERROR_UT_NO_USECONTEXT) ? useClient(key) : null;
-  return client ?
+  return client && (client as IClientWithContext).__getStatus().isOperational ?
     client.getTreatmentsWithConfig(splitNames, attributes) :
     getControlTreatmentsWithConfig(splitNames);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,7 +53,7 @@ export function destroySplitFactory(factory: IFactoryWithClients): Promise<void[
 /**
  * ClientWithContext interface.
  */
-interface IClientWithContext extends SplitIO.IBrowserClient {
+export interface IClientWithContext extends SplitIO.IBrowserClient {
   __getStatus(): {
     isReady: boolean;
     isReadyFromCache: boolean;

--- a/types/splitio/splitio.d.ts
+++ b/types/splitio/splitio.d.ts
@@ -71,7 +71,11 @@ interface ISettings {
     featuresRefreshRate: number,
     impressionsRefreshRate: number,
     impressionsQueueSize: number,
-    metricsRefreshRate: number,
+    /**
+     * @deprecated
+     */
+    metricsRefreshRate?: number,
+    telemetryRefreshRate: number,
     segmentsRefreshRate: number,
     offlineRefreshRate: number,
     eventsPushRate: number,
@@ -93,7 +97,8 @@ interface ISettings {
     events: string,
     sdk: string,
     auth: string,
-    streaming: string
+    streaming: string,
+    telemetry: string
   },
   readonly debug: boolean | LogLevel,
   readonly version: string,
@@ -297,8 +302,15 @@ interface INodeBasicSettings extends ISharedSettings {
      * The SDK sends diagnostic metrics to Split servers. This parameters controls this metric flush period in seconds.
      * @property {number} metricsRefreshRate
      * @default 120
+     * @deprecated This parameter is ignored now. Use `telemetryRefreshRate` instead.
      */
     metricsRefreshRate?: number,
+    /**
+     * The SDK sends diagnostic metrics to Split servers. This parameters controls this metric flush period in seconds.
+     * @property {number} telemetryRefreshRate
+     * @default 3600
+     */
+    telemetryRefreshRate?: number,
     /**
      * The SDK polls Split servers for changes to segment definitions. This parameter controls this polling period in seconds.
      * @property {number} segmentsRefreshRate
@@ -843,7 +855,13 @@ declare namespace SplitIO {
      * @property {string} streaming
      * @default 'https://streaming.split.io'
      */
-    streaming?: string
+    streaming?: string,
+    /**
+     * String property to override the base URL where the SDK will post telemetry data.
+     * @property {string} telemetry
+     * @default 'https://telemetry.split.io/api'
+     */
+    telemetry?: string
   };
 
   /**
@@ -947,8 +965,15 @@ declare namespace SplitIO {
        * The SDK sends diagnostic metrics to Split servers. This parameters controls this metric flush period in seconds.
        * @property {number} metricsRefreshRate
        * @default 120
+       * @deprecated This parameter is ignored now. Use `telemetryRefreshRate` instead.
        */
       metricsRefreshRate?: number,
+      /**
+       * The SDK sends diagnostic metrics to Split servers. This parameters controls this metric flush period in seconds.
+       * @property {number} telemetryRefreshRate
+       * @default 3600
+       */
+      telemetryRefreshRate?: number,
       /**
        * The SDK polls Split servers for changes to segment definitions. This parameter controls this polling period in seconds.
        * @property {number} segmentsRefreshRate

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -12,7 +12,7 @@ export declare function destroySplitFactory(factory: IFactoryWithClients): Promi
 /**
  * ClientWithContext interface.
  */
-interface IClientWithContext extends SplitIO.IBrowserClient {
+export interface IClientWithContext extends SplitIO.IBrowserClient {
     __getStatus(): {
         isReady: boolean;
         isReadyFromCache: boolean;
@@ -41,4 +41,3 @@ export declare function validateSplits(maybeSplits: unknown, listName?: string):
  * Manage client attributes binding
  */
 export declare function initAttributes(client: SplitIO.IBrowserClient, attributes?: SplitIO.Attributes): void;
-export {};


### PR DESCRIPTION
# React SDK

## What did you accomplish?

- Fixed issue with useTreatments hooks, to return control treatments without evaluating splits when the SDK client is not ready or is destroyed, to avoid not ready impressions and warning log.
- Upgrade JS SDK library to include telemetry v2 and other updates.

## How do we test the changes introduced in this PR?

Updated unit tests.

## Extra Notes
