### PR TITLE
Added exports of TypeScript types and interfaces in the library index

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
-1.9.1 (September XX, 2023)
+1.10.0 (September XX, 2023)
+ - Added TypeScript types and interfaces to the library index exports, allowing them to be imported from the library index. For example, `import type { ISplitFactoryProps } from '@splitsoftware/splitio-react';` (Related to issue https://github.com/splitio/react-client/issues/162).
  - Updated linter and other dependencies for vulnerability fixes.
  - Bugfixing - To adhere to the rules of hooks and prevent React warnings, conditional code within hooks was removed. Previously, this code checked for the availability of the hooks API (available in React version 16.8.0 or above) and logged an error message. Now, using hooks with React versions below 16.8.0 will throw an error.
  - Bugfixing - Updated `useClient` and `useTreatments` hooks to re-render and re-evaluate feature flags when they consume a different SDK client than the context and its status updates (i.e., when it emits SDK_READY or other event).

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import {
   SplitContext as ExportedSplitContext,
   SplitSdk as ExportedSplitSdk,
@@ -11,6 +12,16 @@ import {
   useManager as exportedUseManager,
   useTrack as exportedUseTrack,
   useTreatments as exportedUseTreatments,
+  // Checks that types are exported. Otherwise, the test would fail with a TS error.
+  ISplitClientChildProps,
+  ISplitClientProps,
+  ISplitContextValues,
+  ISplitFactoryChildProps,
+  ISplitFactoryProps,
+  ISplitStatus,
+  ISplitTreatmentsChildProps,
+  ISplitTreatmentsProps,
+  IUpdateProps
 } from '../index';
 import { SplitContext } from '../SplitContext';
 import { SplitFactory as SplitioEntrypoint } from '@splitsoftware/splitio/client';

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,16 @@ export { useManager } from './useManager';
 
 // SplitContext
 export { SplitContext } from './SplitContext';
+
+// Types
+export type {
+  ISplitClientChildProps,
+  ISplitClientProps,
+  ISplitContextValues,
+  ISplitFactoryChildProps,
+  ISplitFactoryProps,
+  ISplitStatus,
+  ISplitTreatmentsChildProps,
+  ISplitTreatmentsProps,
+  IUpdateProps
+} from './types';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,3 +10,4 @@ export { useTreatments } from './useTreatments';
 export { useTrack } from './useTrack';
 export { useManager } from './useManager';
 export { SplitContext } from './SplitContext';
+export type { ISplitClientChildProps, ISplitClientProps, ISplitContextValues, ISplitFactoryChildProps, ISplitFactoryProps, ISplitStatus, ISplitTreatmentsChildProps, ISplitTreatmentsProps, IUpdateProps } from './types';


### PR DESCRIPTION
# React SDK

## What did you accomplish?

Added exports of Typescript definitions in the library index, to simplify the usage for TypeScript projects. Otherwise, interfaces have to be imported from a different path, like `src/types` or `types/types`, rather than the index. 

## How do we test the changes introduced in this PR?

Added validation in tests.

## Extra Notes

Related to #162 
