### PR TITLE
Remove EventEmitter max listeners warning to avoid a false memory leak warning

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,7 +3,7 @@
       - Added support for targeting rules based on semantic versions (https://semver.org/).
       - Added special impression label "targeting rule type unsupported by sdk" when the matcher type is not supported by the SDK, which returns 'control' treatment.
       - Updated Split API client to include the flags spec version query parameter for the `splitChanges` and `auth` endpoints.
- - Updated internal use of the SDK client to remove EventEmitter memory leak warnings. These warnings are emitted when using multiple hooks and components from the SDK simultaneously, but they do not indicate an actual memory leak and are irrelevant for SDK usage (Related to https://github.com/splitio/react-client/issues/191).
+ - Updated internal use of the SDK client to remove EventEmitter memory leak warnings. These warnings were emitted when using multiple hooks and components from the SDK simultaneously, but they do not indicate an actual memory leak and are irrelevant for SDK usage (Related to https://github.com/splitio/react-client/issues/191).
 
 1.11.1 (March 26, 2024)
  - Bugfixing - Added tslib as an explicit dependency to avoid issues with some package managers that don't resolve it automatically as a transitive dependency from @splitsoftware/splitio-commons (Related to issue https://github.com/splitio/javascript-client/issues/795).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+1.11.2 (May XX, 2024)
+ - Updated internal use of the SDK client to remove EventEmitter memory leak warnings. These warnings are emitted when using multiple hooks and components from the SDK simultaneously, but they do not indicate an actual memory leak and are irrelevant for SDK usage (Related to https://github.com/splitio/react-client/issues/191).
+
 1.11.1 (March 26, 2024)
  - Bugfixing - Added tslib as an explicit dependency to avoid issues with some package managers that don't resolve it automatically as a transitive dependency from @splitsoftware/splitio-commons (Related to issue https://github.com/splitio/javascript-client/issues/795).
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,7 +54,7 @@ export function getSplitClient(factory: SplitIO.IBrowserSDK, key?: SplitIO.Split
   // Handle client lastUpdate
   if (client.lastUpdate === undefined) {
     // Remove EventEmitter warning emitted when using multiple SDK hooks or components.
-    // Unlike JS SDK, users don't need to use the client directly and so the warning is not relevant.
+    // Unlike JS SDK, users can avoid using the client directly, making the warning irrelevant.
     client.setMaxListeners(0);
 
     const updateLastUpdate = () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,6 +53,10 @@ export function getSplitClient(factory: SplitIO.IBrowserSDK, key?: SplitIO.Split
 
   // Handle client lastUpdate
   if (client.lastUpdate === undefined) {
+    // Remove EventEmitter warning emitted when using multiple SDK hooks or components.
+    // Unlike JS SDK, users don't need to use the client directly and so the warning is not relevant.
+    client.setMaxListeners(0);
+
     const updateLastUpdate = () => {
       const lastUpdate = Date.now();
       client.lastUpdate = lastUpdate > client.lastUpdate ? lastUpdate : client.lastUpdate + 1;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,9 @@
     "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
   },
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "exclude": [
     "./src/__tests__",
     "umd.ts",


### PR DESCRIPTION
# React SDK

## What did you accomplish?

Removed EventEmitters max listener warning, to avoid a false memory leak warning that is logged when using a certain number of SDK hooks and components.

## How do we test the changes introduced in this PR?

Manual validation.

## Extra Notes

Related to https://github.com/splitio/react-client/issues/191
