### PR TITLE
[Breaking change] Upgrade to JS SDK v11. Remove `trafficType` parameter, which is now mandatory in `track` calls.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
   'plugins': [
     'react',
     '@typescript-eslint',
+    'eslint-plugin-tsdoc',
     'import'
   ],
   'rules': {
@@ -62,6 +63,12 @@ module.exports = {
       'no-throw-literal': 'error',
       'import/no-self-import': 'error',
       'import/no-default-export': 'error',
+    }
+  }, {
+    // Enable TSDoc rules for TypeScript files, allowing the use of JSDoc in JS files.
+    'files': ['**/*.ts', '**/*.tsx'],
+    'rules': {
+      'tsdoc/syntax': 'warn'
     }
   }]
 }

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,10 @@
 2.0.0 (October XX, 2024)
  - Added support for targeting rules based on large segments for browsers.
- - Updated @splitsoftware/splitio package to version 10.29.0 that includes minor updates, and updated some transitive dependencies for vulnerability fixes.
+ - Updated @splitsoftware/splitio package to version 11.0.0 that includes major updates, and updated some transitive dependencies for vulnerability fixes.
  - Renamed distribution folders from `/lib` to `/cjs` for CommonJS build, and `/es` to `/esm` for EcmaScript Modules build.
  - BREAKING CHANGES:
       - Updated error handling: using the library modules without wrapping them in a `SplitFactoryProvider` component will now throw an error instead of logging it, as the modules requires the `SplitContext` to work properly.
+      - Removed the `core.trafficType` configuration option and the `trafficType` parameter from the SDK `client()` method, `useSplitClient`, `useTrack`, and `SplitClient` component. This is because traffic types can no longer be bound to SDK clients in JavaScript SDK v11.0.0, and so the traffic type must be provided as first argument in the `track` method calls.
       - Removed deprecated modules: `SplitFactory` component, `useClient`, `useTreatments` and `useManager` hooks, and `withSplitFactory`, `withSplitClient` and `withSplitTreatments` high-order components. Refer to ./MIGRATION-GUIDE.md for instructions on how to migrate to the new alternatives.
       - Renamed TypeScript interfaces `ISplitFactoryProps` to `ISplitFactoryProviderProps`, and `ISplitFactoryChildProps` to `ISplitFactoryProviderChildProps`.
       - Renamed `SplitSdk` to `SplitFactory` function, which is the underlying Split SDK factory, i.e., `import { SplitFactory } from '@splitsoftware/splitio'`.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,12 +1,14 @@
-2.0.0 (October XX, 2024)
- - Added support for targeting rules based on large segments for browsers.
+2.0.0 (November XX, 2024)
+ - Added support for targeting rules based on large segments.
+ - Added support for passing factory instances to the `factory` prop of the `SplitFactoryProvider` component from other SDK packages that extends the `SplitIO.IBrowserSDK` interface, such as `@splitsoftware/splitio-react-native`, `@splitsoftware/splitio-browserjs` and `@splitsoftware/browser-suite` packages.
  - Updated @splitsoftware/splitio package to version 11.0.0 that includes major updates, and updated some transitive dependencies for vulnerability fixes.
- - Renamed distribution folders from `/lib` to `/cjs` for CommonJS build, and `/es` to `/esm` for EcmaScript Modules build.
+ - Renamed distribution folders from `/lib` to `/cjs` for CommonJS build, and `/es` to `/esm` for ECMAScript Modules build.
+ - Bugfixing - When the `config` prop is provided, the `SplitFactoryProvider` now makes the SDK factory and client instances available in the context immediately during the initial render, instead of waiting for the first SDK event (Related to https://github.com/splitio/react-client/issues/198). This change fixes a bug in the `useTrack` hook, which was not retrieving the client's `track` method during the initial render.
  - BREAKING CHANGES:
       - Updated error handling: using the library modules without wrapping them in a `SplitFactoryProvider` component will now throw an error instead of logging it, as the modules requires the `SplitContext` to work properly.
       - Removed the `core.trafficType` configuration option and the `trafficType` parameter from the SDK `client()` method, `useSplitClient`, `useTrack`, and `SplitClient` component. This is because traffic types can no longer be bound to SDK clients in JavaScript SDK v11.0.0, and so the traffic type must be provided as first argument in the `track` method calls.
       - Removed deprecated modules: `SplitFactory` component, `useClient`, `useTreatments` and `useManager` hooks, and `withSplitFactory`, `withSplitClient` and `withSplitTreatments` high-order components. Refer to ./MIGRATION-GUIDE.md for instructions on how to migrate to the new alternatives.
-      - Renamed TypeScript interfaces `ISplitFactoryProps` to `ISplitFactoryProviderProps`, and `ISplitFactoryChildProps` to `ISplitFactoryProviderChildProps`.
+      - Renamed some TypeScript interfaces: `ISplitFactoryProps` to `ISplitFactoryProviderProps`, and `ISplitFactoryChildProps` to `ISplitFactoryProviderChildProps`.
       - Renamed `SplitSdk` to `SplitFactory` function, which is the underlying Split SDK factory, i.e., `import { SplitFactory } from '@splitsoftware/splitio'`.
       - Dropped support for React below 16.8.0, as the library components where rewritten using the React Hooks API available in React v16.8.0 and above. This refactor simplifies code maintenance and reduces bundle size.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.13.1-rc.0",
+  "version": "2.0.0-rc.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splitsoftware/splitio-react",
-      "version": "1.13.1-rc.0",
+      "version": "2.0.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@splitsoftware/splitio": "11.0.0-rc.1",
+        "@splitsoftware/splitio": "11.0.0-rc.5",
         "memoize-one": "^5.1.1",
         "shallowequal": "^1.1.0",
         "tslib": "^2.3.1"
@@ -30,6 +30,7 @@
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-tsdoc": "^0.3.0",
         "husky": "^3.1.0",
         "jest": "^27.2.3",
         "react": "^18.0.0",
@@ -1494,6 +1495,46 @@
       "integrity": "sha512-h/luqw9oAmMF1C/GuUY/PAgZlF4wx71q2bdH+ct8vmjcvseCY32au8XmYy7xZ8l5VJiY/3ltFpr5YiO55v0mzg==",
       "dev": true
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.0.tgz",
+      "integrity": "sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==",
+      "dev": true
+    },
+    "node_modules/@microsoft/tsdoc-config": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.17.0.tgz",
+      "integrity": "sha512-v/EYRXnCAIHxOHW+Plb6OWuUoMotxTN0GLatnpOb1xq0KuTNw/WI3pamJx/UbsoJP5k9MCw1QxvvhPcF9pH3Zg==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/tsdoc": "0.15.0",
+        "ajv": "~8.12.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.2"
+      }
+    },
+    "node_modules/@microsoft/tsdoc-config/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@microsoft/tsdoc-config/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1548,12 +1589,11 @@
       }
     },
     "node_modules/@splitsoftware/splitio": {
-      "version": "11.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-11.0.0-rc.1.tgz",
-      "integrity": "sha512-wBr7i+EUlB7h9ccNgbS0k8aEA3ZEzNrL9dcd5OAATflCnAC5sp33KGgi/anbTCErs344JvRXdzoqAMKV84B3Hw==",
+      "version": "11.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-11.0.0-rc.5.tgz",
+      "integrity": "sha512-n8nDEKtGir4sb5n0vYSoORnK+nFXYCYvGFH55aBNEpUhjMlqu9ocEPtdvtBeuz30yIb18eiiSFAr74WgnPfZHA==",
       "dependencies": {
-        "@splitsoftware/splitio-commons": "2.0.0-rc.2",
-        "@types/ioredis": "^4.28.0",
+        "@splitsoftware/splitio-commons": "2.0.0-rc.6",
         "bloom-filters": "^3.0.0",
         "ioredis": "^4.28.0",
         "js-yaml": "^3.13.1",
@@ -1566,10 +1606,11 @@
       }
     },
     "node_modules/@splitsoftware/splitio-commons": {
-      "version": "2.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.0.0-rc.2.tgz",
-      "integrity": "sha512-QfCg2D5hjg+iuQiEYpsMEjtJ/dcYUsbcXJbvj7BH9t9DfVEplCv09oJcsC6CTFTSeA958y7yqe2EvTy/HVSM5g==",
+      "version": "2.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.0.0-rc.6.tgz",
+      "integrity": "sha512-A4Dk02ShJBjXqtPro6ylBAPc344Unnyk7YmEmvQqv1x4VUKloLw76PI7FgUgG7bM2UH079jSIeUg8HePW2PL1g==",
       "dependencies": {
+        "@types/ioredis": "^4.28.0",
         "tslib": "^2.3.1"
       },
       "peerDependencies": {
@@ -4194,6 +4235,16 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-plugin-tsdoc": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.3.0.tgz",
+      "integrity": "sha512-0MuFdBrrJVBjT/gyhkP2BqpD0np1NxNLfQ38xXDlSs/KVVpKI2A6vN7jx2Rve/CyUsvOsMGwp9KKrinv7q9g3A==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/tsdoc": "0.15.0",
+        "@microsoft/tsdoc-config": "0.17.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -4869,10 +4920,13 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
@@ -5164,6 +5218,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hosted-git-info": {
@@ -5506,12 +5572,15 @@
       "dev": true
     },
     "node_modules/is-core-module": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "dev": true,
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7841,6 +7910,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9185,6 +9260,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -9198,12 +9282,12 @@
       "dev": true
     },
     "node_modules/resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -11983,6 +12067,44 @@
       "integrity": "sha512-h/luqw9oAmMF1C/GuUY/PAgZlF4wx71q2bdH+ct8vmjcvseCY32au8XmYy7xZ8l5VJiY/3ltFpr5YiO55v0mzg==",
       "dev": true
     },
+    "@microsoft/tsdoc": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.0.tgz",
+      "integrity": "sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==",
+      "dev": true
+    },
+    "@microsoft/tsdoc-config": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.17.0.tgz",
+      "integrity": "sha512-v/EYRXnCAIHxOHW+Plb6OWuUoMotxTN0GLatnpOb1xq0KuTNw/WI3pamJx/UbsoJP5k9MCw1QxvvhPcF9pH3Zg==",
+      "dev": true,
+      "requires": {
+        "@microsoft/tsdoc": "0.15.0",
+        "ajv": "~8.12.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -12028,12 +12150,11 @@
       }
     },
     "@splitsoftware/splitio": {
-      "version": "11.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-11.0.0-rc.1.tgz",
-      "integrity": "sha512-wBr7i+EUlB7h9ccNgbS0k8aEA3ZEzNrL9dcd5OAATflCnAC5sp33KGgi/anbTCErs344JvRXdzoqAMKV84B3Hw==",
+      "version": "11.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-11.0.0-rc.5.tgz",
+      "integrity": "sha512-n8nDEKtGir4sb5n0vYSoORnK+nFXYCYvGFH55aBNEpUhjMlqu9ocEPtdvtBeuz30yIb18eiiSFAr74WgnPfZHA==",
       "requires": {
-        "@splitsoftware/splitio-commons": "2.0.0-rc.2",
-        "@types/ioredis": "^4.28.0",
+        "@splitsoftware/splitio-commons": "2.0.0-rc.6",
         "bloom-filters": "^3.0.0",
         "ioredis": "^4.28.0",
         "js-yaml": "^3.13.1",
@@ -12043,10 +12164,11 @@
       }
     },
     "@splitsoftware/splitio-commons": {
-      "version": "2.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.0.0-rc.2.tgz",
-      "integrity": "sha512-QfCg2D5hjg+iuQiEYpsMEjtJ/dcYUsbcXJbvj7BH9t9DfVEplCv09oJcsC6CTFTSeA958y7yqe2EvTy/HVSM5g==",
+      "version": "2.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.0.0-rc.6.tgz",
+      "integrity": "sha512-A4Dk02ShJBjXqtPro6ylBAPc344Unnyk7YmEmvQqv1x4VUKloLw76PI7FgUgG7bM2UH079jSIeUg8HePW2PL1g==",
       "requires": {
+        "@types/ioredis": "^4.28.0",
         "tslib": "^2.3.1"
       }
     },
@@ -14332,6 +14454,16 @@
       "dev": true,
       "requires": {}
     },
+    "eslint-plugin-tsdoc": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.3.0.tgz",
+      "integrity": "sha512-0MuFdBrrJVBjT/gyhkP2BqpD0np1NxNLfQ38xXDlSs/KVVpKI2A6vN7jx2Rve/CyUsvOsMGwp9KKrinv7q9g3A==",
+      "dev": true,
+      "requires": {
+        "@microsoft/tsdoc": "0.15.0",
+        "@microsoft/tsdoc-config": "0.17.0"
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -14597,9 +14729,9 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true
     },
     "function.prototype.name": {
@@ -14802,6 +14934,15 @@
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
+      }
+    },
+    "hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.2"
       }
     },
     "hosted-git-info": {
@@ -15044,12 +15185,12 @@
       }
     },
     "is-core-module": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "dev": true,
       "requires": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
       }
     },
     "is-date-object": {
@@ -16762,6 +16903,12 @@
         }
       }
     },
+    "jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -17809,6 +17956,12 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -17822,12 +17975,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.13.1-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@splitsoftware/splitio": "10.28.1-rc.2",
+        "@splitsoftware/splitio": "11.0.0-rc.1",
         "memoize-one": "^5.1.1",
         "shallowequal": "^1.1.0",
         "tslib": "^2.3.1"
@@ -45,7 +45,7 @@
         "webpack-merge": "^5.8.0"
       },
       "peerDependencies": {
-        "react": ">=16.3.0"
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1548,12 +1548,11 @@
       }
     },
     "node_modules/@splitsoftware/splitio": {
-      "version": "10.28.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-10.28.1-rc.2.tgz",
-      "integrity": "sha512-UwRlu3aBY/e2cDQUxDXZCnLisleOCSUgCQSIN8gGdAKO9QQHG1Vt2cxsxMIGRIIBWUIuuUJ2phVKHM/0M2ZPhw==",
+      "version": "11.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-11.0.0-rc.1.tgz",
+      "integrity": "sha512-wBr7i+EUlB7h9ccNgbS0k8aEA3ZEzNrL9dcd5OAATflCnAC5sp33KGgi/anbTCErs344JvRXdzoqAMKV84B3Hw==",
       "dependencies": {
-        "@splitsoftware/splitio-commons": "1.17.1-rc.1",
-        "@types/google.analytics": "0.0.40",
+        "@splitsoftware/splitio-commons": "2.0.0-rc.2",
         "@types/ioredis": "^4.28.0",
         "bloom-filters": "^3.0.0",
         "ioredis": "^4.28.0",
@@ -1563,14 +1562,13 @@
         "unfetch": "^4.2.0"
       },
       "engines": {
-        "node": ">=6",
-        "npm": ">=3"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@splitsoftware/splitio-commons": {
-      "version": "1.17.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.17.1-rc.1.tgz",
-      "integrity": "sha512-mmDcWW2iyqQF/FzLgPoRA3KXpvswk/sDIhQGWTg3WPkapnA+e4WXb+U/TSGGB/Ig88NlM76FlxMDkrHnBayDXg==",
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.0.0-rc.2.tgz",
+      "integrity": "sha512-QfCg2D5hjg+iuQiEYpsMEjtJ/dcYUsbcXJbvj7BH9t9DfVEplCv09oJcsC6CTFTSeA958y7yqe2EvTy/HVSM5g==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -1846,11 +1844,6 @@
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
-    },
-    "node_modules/@types/google.analytics": {
-      "version": "0.0.40",
-      "resolved": "https://registry.npmjs.org/@types/google.analytics/-/google.analytics-0.0.40.tgz",
-      "integrity": "sha512-R3HpnLkqmKxhUAf8kIVvDVGJqPtaaZlW4yowNwjOZUTmYUQEgHh8Nh5wkSXKMroNAuQM8gbXJHmNbbgA8tdb7Q=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -12035,12 +12028,11 @@
       }
     },
     "@splitsoftware/splitio": {
-      "version": "10.28.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-10.28.1-rc.2.tgz",
-      "integrity": "sha512-UwRlu3aBY/e2cDQUxDXZCnLisleOCSUgCQSIN8gGdAKO9QQHG1Vt2cxsxMIGRIIBWUIuuUJ2phVKHM/0M2ZPhw==",
+      "version": "11.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-11.0.0-rc.1.tgz",
+      "integrity": "sha512-wBr7i+EUlB7h9ccNgbS0k8aEA3ZEzNrL9dcd5OAATflCnAC5sp33KGgi/anbTCErs344JvRXdzoqAMKV84B3Hw==",
       "requires": {
-        "@splitsoftware/splitio-commons": "1.17.1-rc.1",
-        "@types/google.analytics": "0.0.40",
+        "@splitsoftware/splitio-commons": "2.0.0-rc.2",
         "@types/ioredis": "^4.28.0",
         "bloom-filters": "^3.0.0",
         "ioredis": "^4.28.0",
@@ -12051,9 +12043,9 @@
       }
     },
     "@splitsoftware/splitio-commons": {
-      "version": "1.17.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.17.1-rc.1.tgz",
-      "integrity": "sha512-mmDcWW2iyqQF/FzLgPoRA3KXpvswk/sDIhQGWTg3WPkapnA+e4WXb+U/TSGGB/Ig88NlM76FlxMDkrHnBayDXg==",
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.0.0-rc.2.tgz",
+      "integrity": "sha512-QfCg2D5hjg+iuQiEYpsMEjtJ/dcYUsbcXJbvj7BH9t9DfVEplCv09oJcsC6CTFTSeA958y7yqe2EvTy/HVSM5g==",
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -12268,11 +12260,6 @@
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
-    },
-    "@types/google.analytics": {
-      "version": "0.0.40",
-      "resolved": "https://registry.npmjs.org/@types/google.analytics/-/google.analytics-0.0.40.tgz",
-      "integrity": "sha512-R3HpnLkqmKxhUAf8kIVvDVGJqPtaaZlW4yowNwjOZUTmYUQEgHh8Nh5wkSXKMroNAuQM8gbXJHmNbbgA8tdb7Q=="
     },
     "@types/graceful-fs": {
       "version": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "1.13.1-rc.0",
+  "version": "2.0.0-rc.2",
   "description": "A React library to easily integrate and use Split JS SDK",
   "main": "cjs/index.js",
   "module": "esm/index.js",
@@ -26,7 +26,7 @@
     "check": "npm run check:lint && npm run check:types",
     "check:lint": "eslint 'src/**/*.ts*'",
     "check:types": "tsc --noEmit",
-    "test": "jest src",
+    "test": "jest src --silent",
     "test:watch": "npm test -- --watch",
     "test:coverage": "jest src --coverage",
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand",
@@ -63,7 +63,7 @@
   },
   "homepage": "https://github.com/splitio/react-client#readme",
   "dependencies": {
-    "@splitsoftware/splitio": "11.0.0-rc.1",
+    "@splitsoftware/splitio": "11.0.0-rc.5",
     "memoize-one": "^5.1.1",
     "shallowequal": "^1.1.0",
     "tslib": "^2.3.1"
@@ -84,6 +84,7 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-tsdoc": "^0.3.0",
     "husky": "^3.1.0",
     "jest": "^27.2.3",
     "react": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "homepage": "https://github.com/splitio/react-client#readme",
   "dependencies": {
-    "@splitsoftware/splitio": "10.28.1-rc.2",
+    "@splitsoftware/splitio": "11.0.0-rc.1",
     "memoize-one": "^5.1.1",
     "shallowequal": "^1.1.0",
     "tslib": "^2.3.1"

--- a/src/SplitClient.tsx
+++ b/src/SplitClient.tsx
@@ -8,7 +8,7 @@ import { useSplitClient } from './useSplitClient';
  * Children components will have access to the new client when accessing Split Context.
  *
  * The underlying SDK client can be changed during the component lifecycle
- * if the component is updated with a different splitKey or trafficType prop.
+ * if the component is updated with a different splitKey prop.
  *
  * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#advanced-instantiate-multiple-sdk-clients}
  */

--- a/src/SplitTreatments.tsx
+++ b/src/SplitTreatments.tsx
@@ -14,7 +14,7 @@ import { useSplitTreatments } from './useSplitTreatments';
 export function SplitTreatments(props: ISplitTreatmentsProps) {
   const { children } = props;
   // SplitTreatments doesn't update on SDK events, since it is inside SplitFactory and/or SplitClient.
-  const context = useSplitTreatments({ updateOnSdkReady: false, updateOnSdkTimedout: false, ...props });
+  const context = useSplitTreatments({ ...props, updateOnSdkReady: false, updateOnSdkReadyFromCache: false });
 
   return (
     <SplitContext.Provider value={context}>

--- a/src/__tests__/SplitClient.test.tsx
+++ b/src/__tests__/SplitClient.test.tsx
@@ -344,7 +344,7 @@ describe('SplitClient', () => {
     function Component({ attributesFactory, attributesClient, splitKey, testSwitch, factory }: TestComponentProps) {
       return (
         <SplitFactoryProvider factory={factory} attributes={attributesFactory} >
-          <SplitClient splitKey={splitKey} attributes={attributesClient} trafficType='user' >
+          <SplitClient splitKey={splitKey} attributes={attributesClient} >
             {() => {
               testSwitch(done, splitKey);
               return null;

--- a/src/__tests__/SplitClient.test.tsx
+++ b/src/__tests__/SplitClient.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, act } from '@testing-library/react';
 
 /** Mocks and test utils */
-import { mockSdk, Event } from './testUtils/mockSplitFactory';
+import { mockSdk, Event, getLastInstance } from './testUtils/mockSplitFactory';
 jest.mock('@splitsoftware/splitio/client', () => {
   return { SplitFactory: mockSdk() };
 });
@@ -14,7 +14,7 @@ import { ISplitClientChildProps } from '../types';
 import { SplitFactoryProvider } from '../SplitFactoryProvider';
 import { SplitClient } from '../SplitClient';
 import { SplitContext } from '../SplitContext';
-import { INITIAL_CONTEXT, testAttributesBinding, TestComponentProps } from './testUtils/utils';
+import { INITIAL_STATUS, testAttributesBinding, TestComponentProps } from './testUtils/utils';
 import { IClientWithContext } from '../utils';
 import { EXCEPTION_NO_SFP } from '../constants';
 
@@ -25,7 +25,11 @@ describe('SplitClient', () => {
       <SplitFactoryProvider config={sdkBrowser} >
         <SplitClient splitKey='user1' >
           {(childProps: ISplitClientChildProps) => {
-            expect(childProps).toEqual(INITIAL_CONTEXT);
+            expect(childProps).toEqual({
+              ...INITIAL_STATUS,
+              factory: getLastInstance(SplitFactory),
+              client: getLastInstance(SplitFactory).client('user1'),
+            });
 
             return null;
           }}
@@ -47,7 +51,7 @@ describe('SplitClient', () => {
         <SplitClient splitKey={sdkBrowser.core.key} >
           {(childProps: ISplitClientChildProps) => {
             expect(childProps).toEqual({
-              ...INITIAL_CONTEXT,
+              ...INITIAL_STATUS,
               factory : outerFactory,
               client: outerFactory.client(),
               isReady: true,
@@ -210,8 +214,7 @@ describe('SplitClient', () => {
             count++;
 
             // side effect in the render phase
-            if (!(client as IClientWithContext).__getStatus().isReady) {
-              console.log('emit');
+            if (!(client as any).__getStatus().isReady) {
               (client as any).__emitter__.emit(Event.SDK_READY);
             }
 
@@ -232,7 +235,7 @@ describe('SplitClient', () => {
         <SplitContext.Consumer>
           {(value) => {
             expect(value).toEqual({
-              ...INITIAL_CONTEXT,
+              ...INITIAL_STATUS,
               factory: outerFactory,
               client: outerFactory.client('user2'),
             });

--- a/src/__tests__/SplitContext.test.tsx
+++ b/src/__tests__/SplitContext.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { SplitContext } from '../SplitContext';
 import { SplitFactoryProvider } from '../SplitFactoryProvider';
-import { INITIAL_CONTEXT } from './testUtils/utils';
+import { INITIAL_STATUS } from './testUtils/utils';
 
 /**
  * Test default SplitContext value
@@ -23,7 +23,11 @@ test('SplitContext.Consumer shows value when wrapped in a SplitFactoryProvider',
     <SplitFactoryProvider >
       <SplitContext.Consumer>
         {(value) => {
-          expect(value).toEqual(INITIAL_CONTEXT);
+          expect(value).toEqual({
+            ...INITIAL_STATUS,
+            factory: undefined,
+            client: undefined
+          });
           return null;
         }}
       </SplitContext.Consumer>

--- a/src/__tests__/testUtils/mockSplitFactory.ts
+++ b/src/__tests__/testUtils/mockSplitFactory.ts
@@ -26,7 +26,7 @@ function parseKey(key: SplitIO.SplitKey): SplitIO.SplitKey {
     };
   }
 }
-function buildInstanceId(key: any, trafficType: string | undefined) {
+function buildInstanceId(key: any, trafficType?: string) {
   return `${key.matchingKey ? key.matchingKey : key}-${key.bucketingKey ? key.bucketingKey : key}-${trafficType !== undefined ? trafficType : ''}`;
 }
 
@@ -34,7 +34,7 @@ export function mockSdk() {
 
   return jest.fn((config: SplitIO.IBrowserSettings, __updateModules) => {
 
-    function mockClient(_key: SplitIO.SplitKey, _trafficType?: string) {
+    function mockClient(_key: SplitIO.SplitKey) {
       // Readiness
       let isReady = false;
       let isReadyFromCache = false;
@@ -135,11 +135,10 @@ export function mockSdk() {
 
     // Cache of clients
     const __clients__: { [instanceId: string]: any } = {};
-    const client = jest.fn((key?: string, trafficType?: string) => {
+    const client = jest.fn((key?: string) => {
       const clientKey = key || parseKey(config.core.key);
-      const clientTT = trafficType || config.core.trafficType;
-      const instanceId = buildInstanceId(clientKey, clientTT);
-      return __clients__[instanceId] || (__clients__[instanceId] = mockClient(clientKey, clientTT));
+      const instanceId = buildInstanceId(clientKey);
+      return __clients__[instanceId] || (__clients__[instanceId] = mockClient(clientKey));
     });
 
     // Factory destroy

--- a/src/__tests__/testUtils/mockSplitFactory.ts
+++ b/src/__tests__/testUtils/mockSplitFactory.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'events';
-import SplitIO from '@splitsoftware/splitio/types/splitio';
 import jsSdkPackageJson from '@splitsoftware/splitio/package.json';
 import reactSdkPackageJson from '../../../package.json';
 
@@ -163,4 +162,8 @@ export function mockSdk() {
     return factory;
   });
 
+}
+
+export function getLastInstance(SplitFactoryMock: any) {
+  return SplitFactoryMock.mock.results.slice(-1)[0].value;
 }

--- a/src/__tests__/testUtils/sdkConfigs.ts
+++ b/src/__tests__/testUtils/sdkConfigs.ts
@@ -1,5 +1,3 @@
-import SplitIO from '@splitsoftware/splitio/types/splitio';
-
 export const sdkBrowser: SplitIO.IBrowserSettings = {
   core: {
     authorizationKey: 'sdk-key',

--- a/src/__tests__/testUtils/utils.tsx
+++ b/src/__tests__/testUtils/utils.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { ISplitContextValues } from '../../types';
+import { ISplitStatus } from '../../types';
 const { SplitFactory: originalSplitFactory } = jest.requireActual('@splitsoftware/splitio/client');
 
 export interface TestComponentProps {
@@ -116,9 +116,7 @@ export function testAttributesBinding(Component: React.FunctionComponent<TestCom
   wrapper.rerender(<Component splitKey={undefined} attributesFactory={undefined} attributesClient={undefined} testSwitch={attributesBindingSwitch} factory={factory} />);
 }
 
-export const INITIAL_CONTEXT: ISplitContextValues = {
-  client: undefined,
-  factory: undefined,
+export const INITIAL_STATUS: ISplitStatus = {
   isReady: false,
   isReadyFromCache: false,
   isTimedout: false,

--- a/src/__tests__/useSplitClient.test.tsx
+++ b/src/__tests__/useSplitClient.test.tsx
@@ -56,12 +56,12 @@ describe('useSplitClient', () => {
       <SplitFactoryProvider factory={outerFactory} >
         {React.createElement(() => {
           (outerFactory.client as jest.Mock).mockClear();
-          client = useSplitClient({ splitKey: 'user2', trafficType: 'user' }).client;
+          client = useSplitClient({ splitKey: 'user2' }).client;
           return null;
         })}
       </SplitFactoryProvider>
     );
-    expect(outerFactory.client as jest.Mock).toBeCalledWith('user2', 'user');
+    expect(outerFactory.client as jest.Mock).toBeCalledWith('user2');
     expect(outerFactory.client as jest.Mock).toHaveReturnedWith(client);
   });
 
@@ -70,7 +70,7 @@ describe('useSplitClient', () => {
       render(
         React.createElement(() => {
           useSplitClient();
-          useSplitClient({ splitKey: 'user2', trafficType: 'user' });
+          useSplitClient({ splitKey: 'user2' });
           return null;
         })
       );
@@ -81,7 +81,7 @@ describe('useSplitClient', () => {
 
     // eslint-disable-next-line react/prop-types
     const InnerComponent = ({ splitKey, attributesClient, testSwitch }) => {
-      useSplitClient({ splitKey, trafficType: 'user', attributes: attributesClient });
+      useSplitClient({ splitKey, attributes: attributesClient });
       testSwitch(done, splitKey);
       return null;
     };
@@ -112,7 +112,7 @@ describe('useSplitClient', () => {
           <SplitContext.Consumer>
             {() => countSplitContext++}
           </SplitContext.Consumer>
-          <SplitClient splitKey={sdkBrowser.core.key} trafficType={sdkBrowser.core.trafficType}
+          <SplitClient splitKey={sdkBrowser.core.key}
             /* Disabling update props is ineffective because the wrapping SplitFactoryProvider has them enabled: */
             updateOnSdkReady={false} updateOnSdkReadyFromCache={false}
           >
@@ -120,8 +120,8 @@ describe('useSplitClient', () => {
           </SplitClient>
           {React.createElement(() => {
             // Equivalent to
-            // - Using config key and traffic type: `const { client } = useSplitClient(sdkBrowser.core.key, sdkBrowser.core.trafficType, { att1: 'att1' });`
-            // - Disabling update props, since the wrapping SplitFactoryProvider has them enabled: `const { client } = useSplitClient(undefined, undefined, { att1: 'att1' }, { updateOnSdkReady: false, updateOnSdkReadyFromCache: false });`
+            // - Using config key: `const { client } = useSplitClient({ splitKey: sdkBrowser.core.key, attributes: { att1: 'att1' } });`
+            // - Disabling update props, since the wrapping SplitFactoryProvider has them enabled: `const { client } = useSplitClient({ attributes: { att1: 'att1' }, updateOnSdkReady: false, updateOnSdkReadyFromCache: false });`
             const { client } = useSplitClient({ attributes: { att1: 'att1' } });
             expect(client).toBe(mainClient); // Assert that the main client was retrieved.
             expect(client!.getAttributes()).toEqual({ att1: 'att1' }); // Assert that the client was retrieved with the provided attributes.
@@ -141,7 +141,7 @@ describe('useSplitClient', () => {
             {() => { countSplitClientWithUpdate++; return null }}
           </SplitClient>
           {React.createElement(() => {
-            useSplitClient({ splitKey: sdkBrowser.core.key, trafficType: sdkBrowser.core.trafficType, updateOnSdkUpdate: true }).client;
+            useSplitClient({ splitKey: sdkBrowser.core.key, updateOnSdkUpdate: true }).client;
             countUseSplitClientWithUpdate++;
             return null;
           })}

--- a/src/__tests__/useSplitManager.test.tsx
+++ b/src/__tests__/useSplitManager.test.tsx
@@ -14,6 +14,7 @@ import { getStatus } from '../utils';
 import { SplitFactoryProvider } from '../SplitFactoryProvider';
 import { useSplitManager } from '../useSplitManager';
 import { EXCEPTION_NO_SFP } from '../constants';
+import { INITIAL_STATUS } from './testUtils/utils';
 
 describe('useSplitManager', () => {
 
@@ -33,12 +34,7 @@ describe('useSplitManager', () => {
       manager: outerFactory.manager(),
       client: outerFactory.client(),
       factory: outerFactory,
-      hasTimedout: false,
-      isDestroyed: false,
-      isReady: false,
-      isReadyFromCache: false,
-      isTimedout: false,
-      lastUpdate: 0,
+      ...INITIAL_STATUS,
     });
 
     act(() => (outerFactory.client() as any).__emitter__.emit(Event.SDK_READY));

--- a/src/__tests__/useTrack.test.tsx
+++ b/src/__tests__/useTrack.test.tsx
@@ -62,22 +62,21 @@ describe('useTrack', () => {
     expect(track).toHaveReturnedWith(trackResult);
   });
 
-  test('returns the track method bound to a new client given a splitKey and optional trafficType.', () => {
+  test('returns the track method bound to a new client given a splitKey.', () => {
     const outerFactory = SplitFactory(sdkBrowser);
-    let boundTrack;
     let trackResult;
 
     render(
       <SplitFactoryProvider factory={outerFactory} >
         {React.createElement(() => {
-          boundTrack = useTrack('user2', tt);
-          trackResult = boundTrack(eventType, value, properties);
+          const boundTrack = useTrack('user2');
+          trackResult = boundTrack(tt, eventType, value, properties);
           return null;
         })}
       </SplitFactoryProvider>,
     );
-    const track = outerFactory.client('user2', tt).track as jest.Mock;
-    expect(track).toBeCalledWith(eventType, value, properties);
+    const track = outerFactory.client('user2').track as jest.Mock;
+    expect(track).toBeCalledWith(tt, eventType, value, properties);
     expect(track).toHaveReturnedWith(trackResult);
   });
 
@@ -85,8 +84,8 @@ describe('useTrack', () => {
     expect(() => {
       render(
         React.createElement(() => {
-          const track = useTrack('user2', tt);
-          track(eventType, value, properties);
+          const track = useTrack('user2');
+          track(tt, eventType, value, properties);
           return null;
         }),
       );

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,6 +1,5 @@
 import { CONTROL_WITH_CONFIG } from '../constants';
 import { getControlTreatmentsWithConfig } from '../utils';
-import SplitIO from '@splitsoftware/splitio/types/splitio';
 
 describe('getControlTreatmentsWithConfig', () => {
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-import SplitIO from '@splitsoftware/splitio/types/splitio';
 import type { ReactNode } from 'react';
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,12 +146,6 @@ export interface IUseSplitClientOptions extends IUpdateProps {
   splitKey?: SplitIO.SplitKey;
 
   /**
-   * Traffic type associated with the customer identifier.
-   * If no provided here or at the config object, it will be required on the client.track() calls.
-   */
-  trafficType?: string;
-
-  /**
    * An object of type Attributes used to evaluate the feature flags.
    */
   attributes?: SplitIO.Attributes;

--- a/src/useSplitClient.ts
+++ b/src/useSplitClient.ts
@@ -11,7 +11,7 @@ export const DEFAULT_UPDATE_OPTIONS = {
 };
 
 /**
- * 'useSplitClient' is a hook that returns an Split Context object with the client and its status corresponding to the provided key and trafficType.
+ * 'useSplitClient' is a hook that returns an Split Context object with the client and its status corresponding to the provided key.
  * It uses the 'useContext' hook to access the context, which is updated by SplitFactoryProvider and SplitClient components in the hierarchy of components.
  *
  * @returns A Split Context object
@@ -25,7 +25,7 @@ export const DEFAULT_UPDATE_OPTIONS = {
  */
 export function useSplitClient(options?: IUseSplitClientOptions): ISplitContextValues {
   const {
-    updateOnSdkReady, updateOnSdkReadyFromCache, updateOnSdkTimedout, updateOnSdkUpdate, splitKey, trafficType, attributes
+    updateOnSdkReady, updateOnSdkReadyFromCache, updateOnSdkTimedout, updateOnSdkUpdate, splitKey, attributes
   } = { ...DEFAULT_UPDATE_OPTIONS, ...options };
 
   const context = useSplitContext();
@@ -34,7 +34,7 @@ export function useSplitClient(options?: IUseSplitClientOptions): ISplitContextV
   let client = contextClient as IClientWithContext;
   if (splitKey && factory) {
     // @TODO `getSplitClient` starts client sync. Move side effects to useEffect
-    client = getSplitClient(factory, splitKey, trafficType);
+    client = getSplitClient(factory, splitKey);
   }
   initAttributes(client, attributes);
 

--- a/src/useTrack.ts
+++ b/src/useTrack.ts
@@ -11,8 +11,8 @@ const noOpFalse = () => false;
  *
  * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#track}
  */
-export function useTrack(splitKey?: SplitIO.SplitKey, trafficType?: string): SplitIO.IBrowserClient['track'] {
+export function useTrack(splitKey?: SplitIO.SplitKey): SplitIO.IBrowserClient['track'] {
   // All update options are false to avoid re-renders. The track method doesn't need the client to be operational.
-  const { client } = useSplitClient({ splitKey, trafficType, updateOnSdkReady: false, updateOnSdkReadyFromCache: false });
+  const { client } = useSplitClient({ splitKey, updateOnSdkReady: false, updateOnSdkReadyFromCache: false });
   return client ? client.track.bind(client) : noOpFalse;
 }

--- a/src/useTrack.ts
+++ b/src/useTrack.ts
@@ -4,15 +4,16 @@ import { useSplitClient } from './useSplitClient';
 const noOpFalse = () => false;
 
 /**
- * 'useTrack' is a hook that returns the track method from a Split client.
- * It uses the 'useContext' hook to access the client from the Split context.
+ * 'useTrack' is a hook that retrieves the track method from a Split client.
+ * It uses the 'useSplitClient' hook to access the client from the Split context.
+ * Basically, it is a shortcut for `const track = useSplitClient().client?.track || (() => false);`.
  *
- * @returns A track function bound to a Split client. If the client is not available, the result is a no-op function that returns false.
+ * @returns A track function of the Split client. If the client is not available, the result is a no-op function that returns false.
  *
  * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#track}
  */
 export function useTrack(splitKey?: SplitIO.SplitKey): SplitIO.IBrowserClient['track'] {
   // All update options are false to avoid re-renders. The track method doesn't need the client to be operational.
   const { client } = useSplitClient({ splitKey, updateOnSdkReady: false, updateOnSdkReadyFromCache: false });
-  return client ? client.track.bind(client) : noOpFalse;
+  return client ? client.track : noOpFalse;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,13 +46,13 @@ export function getSplitFactory(config: SplitIO.IBrowserSettings) {
 }
 
 // idempotent operation
-export function getSplitClient(factory: SplitIO.IBrowserSDK, key?: SplitIO.SplitKey, trafficType?: string): IClientWithContext {
+export function getSplitClient(factory: SplitIO.IBrowserSDK, key?: SplitIO.SplitKey): IClientWithContext {
   // factory.client is an idempotent operation
-  const client = (key !== undefined ? factory.client(key, trafficType) : factory.client()) as IClientWithContext;
+  const client = (key !== undefined ? factory.client(key) : factory.client()) as IClientWithContext;
 
   // Remove EventEmitter warning emitted when using multiple SDK hooks or components.
   // Unlike JS SDK, users don't need to access the client directly, making the warning irrelevant.
-  client.setMaxListeners(0);
+  client.setMaxListeners && client.setMaxListeners(0);
 
   return client;
 }


### PR DESCRIPTION
# React SDK

## What did you accomplish?

## How do we test the changes introduced in this PR?

## Extra Notes
