### PR TITLE
Updated `React` default imports to the recommended namespace imports

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+2.0.2 (December XX, 2024)
+ - Updated the import of the React library from default imports to namespace imports for better compatibility with React, TypeScript, ES modules, and tree shaking.
+
 2.0.1 (December 4, 2024)
  - Updated @splitsoftware/splitio package to version 11.0.3 that includes some improvements and bugfixes.
  - Updated internal handling of the `updateOnSdkTimedout` param to remove the wrong log "[ERROR] A listener was added for SDK_READY_TIMED_OUT on the SDK, which has already fired and won't be emitted again".

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "2.0.1",
+  "version": "2.0.2-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splitsoftware/splitio-react",
-      "version": "2.0.1",
+      "version": "2.0.2-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@splitsoftware/splitio": "11.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "2.0.1",
+  "version": "2.0.2-rc.0",
   "description": "A React library to easily integrate and use Split JS SDK",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/SplitClient.tsx
+++ b/src/SplitClient.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { SplitContext } from './SplitContext';
 import { ISplitClientProps } from './types';
 import { useSplitClient } from './useSplitClient';

--- a/src/SplitContext.ts
+++ b/src/SplitContext.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { ISplitContextValues } from './types';
 import { EXCEPTION_NO_SFP } from './constants';
 

--- a/src/SplitFactoryProvider.tsx
+++ b/src/SplitFactoryProvider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { ISplitFactoryProviderProps } from './types';
 import { VERSION, WARN_SF_CONFIG_AND_FACTORY } from './constants';

--- a/src/SplitTreatments.tsx
+++ b/src/SplitTreatments.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { SplitContext } from './SplitContext';
 import { ISplitTreatmentsProps } from './types';

--- a/src/__tests__/SplitClient.test.tsx
+++ b/src/__tests__/SplitClient.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render, act } from '@testing-library/react';
 
 /** Mocks and test utils */

--- a/src/__tests__/SplitContext.test.tsx
+++ b/src/__tests__/SplitContext.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { SplitContext } from '../SplitContext';
 import { SplitFactoryProvider } from '../SplitFactoryProvider';

--- a/src/__tests__/SplitFactoryProvider.test.tsx
+++ b/src/__tests__/SplitFactoryProvider.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render, act } from '@testing-library/react';
 
 /** Mocks */

--- a/src/__tests__/SplitTreatments.test.tsx
+++ b/src/__tests__/SplitTreatments.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render, RenderResult, act } from '@testing-library/react';
 
 /** Mocks */

--- a/src/__tests__/testUtils/utils.tsx
+++ b/src/__tests__/testUtils/utils.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { ISplitStatus } from '../../types';
 const { SplitFactory: originalSplitFactory } = jest.requireActual('@splitsoftware/splitio/client');

--- a/src/__tests__/useSplitClient.test.tsx
+++ b/src/__tests__/useSplitClient.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { act, render } from '@testing-library/react';
 
 /** Mocks */

--- a/src/__tests__/useSplitManager.test.tsx
+++ b/src/__tests__/useSplitManager.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { act, render } from '@testing-library/react';
 
 /** Mocks */

--- a/src/__tests__/useSplitTreatments.test.tsx
+++ b/src/__tests__/useSplitTreatments.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { act, render } from '@testing-library/react';
 
 /** Mocks */

--- a/src/__tests__/withSplitClient.test.tsx
+++ b/src/__tests__/withSplitClient.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 
 /** Mocks */

--- a/src/__tests__/withSplitFactory.test.tsx
+++ b/src/__tests__/withSplitFactory.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 
 /** Mocks */

--- a/src/__tests__/withSplitTreatments.test.tsx
+++ b/src/__tests__/withSplitTreatments.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { act, render } from '@testing-library/react';
 
 /** Mocks */

--- a/src/useSplitClient.ts
+++ b/src/useSplitClient.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useSplitContext } from './SplitContext';
 import { getSplitClient, initAttributes, getStatus } from './utils';
 import { ISplitContextValues, IUseSplitClientOptions } from './types';

--- a/src/useSplitTreatments.ts
+++ b/src/useSplitTreatments.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { memoizeGetTreatmentsWithConfig } from './utils';
 import { ISplitTreatmentsChildProps, IUseSplitTreatmentsOptions } from './types';
 import { useSplitClient } from './useSplitClient';

--- a/src/withSplitClient.tsx
+++ b/src/withSplitClient.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { ISplitClientChildProps } from './types';
 import { SplitClient } from './SplitClient';
 

--- a/src/withSplitFactory.tsx
+++ b/src/withSplitFactory.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { ISplitFactoryChildProps } from './types';
 import { SplitFactoryProvider } from './SplitFactoryProvider';
 import { SplitClient } from './SplitClient';

--- a/src/withSplitTreatments.tsx
+++ b/src/withSplitTreatments.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { ISplitTreatmentsChildProps } from './types';
 import { SplitTreatments } from './SplitTreatments';
 


### PR DESCRIPTION
# React SDK

## What did you accomplish?

Updated `React` default imports to namespace imports as this is [the recommended approach](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports) for improved compatibility:
- Doesn't require `esModuleInterop: true` in TypeScript configurations.
- Some build/bundle tools and configurations may handle ES namespace imports more predictably for tree-shaking.

## How do we test the changes introduced in this PR?

Validated in projects using the latest React SDK version and minimum version required by the SDK.

## Extra Notes
