### PR TITLE
Fix `useSplitClient` hook to properly respect `updateOn<Event>` options when the function is re-called

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 2.1.1 (April 8, 2025)
- - Bugfix - Fixed `useSplitClient` and `useSplitTreatments` hooks to properly respect `updateOn<Event>` options. Previously, if the hooks were re-called due to a component re-render, they used the latest version of the SDK client status ignoring when `updateOn<Event>` options were set to `false`.
+ - Bugfix - Fixed `useSplitClient` and `useSplitTreatments` hooks to properly respect `updateOn<Event>` options. Previously, if the hooks were re-called due to a component re-render, they used the latest version of the SDK client status ignoring when `updateOn<Event>` options were set to `false` and resulting in unexpected changes in treatment values.
 
 2.1.0 (March 28, 2025)
  - Added a new optional `properties` argument to the options object of the `useSplitTreatments` hook, allowing to pass a map of properties to append to the generated impressions sent to Split backend. Read more in our docs.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 2.1.1 (April 8, 2025)
- - Bugfix - Fixed `useSplitClient` and `useSplitTreatments` hooks to properly respect `updateOn<Event>` options. Previously, if the hooks were re-called due to a component re-render, it used the latest version of the SDK client status ignoring when `updateOn<Event>` options were set to `false`.
+ - Bugfix - Fixed `useSplitClient` and `useSplitTreatments` hooks to properly respect `updateOn<Event>` options. Previously, if the hooks were re-called due to a component re-render, they used the latest version of the SDK client status ignoring when `updateOn<Event>` options were set to `false`.
 
 2.1.0 (March 28, 2025)
  - Added a new optional `properties` argument to the options object of the `useSplitTreatments` hook, allowing to pass a map of properties to append to the generated impressions sent to Split backend. Read more in our docs.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+2.1.1 (April 8, 2025)
+ - Bugfix - Fixed `useSplitClient` and `useSplitTreatments` hooks to properly respect `updateOn<Event>` options. Previously, if the hooks were re-called due to a component re-render, it used the latest version of the SDK client status ignoring when `updateOn<Event>` options were set to `false`.
+
 2.1.0 (March 28, 2025)
  - Added a new optional `properties` argument to the options object of the `useSplitTreatments` hook, allowing to pass a map of properties to append to the generated impressions sent to Split backend. Read more in our docs.
  - Updated @splitsoftware/splitio package to version 11.2.0 that includes some minor updates:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "2.1.0",
+  "version": "2.1.1-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splitsoftware/splitio-react",
-      "version": "2.1.0",
+      "version": "2.1.1-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@splitsoftware/splitio": "11.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "2.1.1-rc.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splitsoftware/splitio-react",
-      "version": "2.1.1-rc.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@splitsoftware/splitio": "11.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "2.1.1-rc.0",
+  "version": "2.1.1",
   "description": "A React library to easily integrate and use Split JS SDK",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-react",
-  "version": "2.1.0",
+  "version": "2.1.1-rc.0",
   "description": "A React library to easily integrate and use Split JS SDK",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/__tests__/useSplitClient.test.tsx
+++ b/src/__tests__/useSplitClient.test.tsx
@@ -147,7 +147,7 @@ describe('useSplitClient', () => {
                 expect([isReady, isReadyFromCache, hasTimedout]).toEqual([true, true, false]);
                 expect(lastUpdate).toBeGreaterThan(previousLastUpdate);
                 break;
-              case 4: // Forced update
+              case 4: // Forced re-render, lastUpdate doesn't change after SDK_UPDATE due to updateOnSdkUpdate = false
                 expect([isReady, isReadyFromCache, hasTimedout]).toEqual([true, true, false]);
                 expect(lastUpdate).toBe(previousLastUpdate);
                 break;

--- a/src/__tests__/useSplitClient.test.tsx
+++ b/src/__tests__/useSplitClient.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { act, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 
 /** Mocks */
 import { mockSdk, Event } from './testUtils/mockSplitFactory';
@@ -87,8 +87,9 @@ describe('useSplitClient', () => {
 
     let countSplitContext = 0, countUseSplitClient = 0, countUseSplitClientUser2 = 0;
     let countUseSplitClientWithoutUpdate = 0, countUseSplitClientUser2WithoutTimeout = 0;
+    let previousLastUpdate = -1;
 
-    render(
+    const { getByTestId } = render(
       <SplitFactoryProvider factory={outerFactory} >
         <>
           <SplitContext.Consumer>
@@ -129,9 +130,35 @@ describe('useSplitClient', () => {
             return null;
           })}
           {React.createElement(() => {
-            useSplitClient({ splitKey: sdkBrowser.core.key, updateOnSdkUpdate: false }).client;
+            const [state, setState] = React.useState(false);
+
+            const { isReady, isReadyFromCache, hasTimedout, lastUpdate } = useSplitClient({ splitKey: sdkBrowser.core.key, updateOnSdkUpdate: false });
             countUseSplitClientWithoutUpdate++;
-            return null;
+            switch (countUseSplitClientWithoutUpdate) {
+              case 1: // initial render
+                expect([isReady, isReadyFromCache, hasTimedout]).toEqual([false, false, false]);
+                expect(lastUpdate).toBe(0);
+                break;
+              case 2: // SDK_READY_FROM_CACHE
+                expect([isReady, isReadyFromCache, hasTimedout]).toEqual([false, true, false]);
+                expect(lastUpdate).toBeGreaterThan(previousLastUpdate);
+                break;
+              case 3: // SDK_READY
+                expect([isReady, isReadyFromCache, hasTimedout]).toEqual([true, true, false]);
+                expect(lastUpdate).toBeGreaterThan(previousLastUpdate);
+                break;
+              case 4: // Forced update
+                expect([isReady, isReadyFromCache, hasTimedout]).toEqual([true, true, false]);
+                expect(lastUpdate).toBe(previousLastUpdate);
+                break;
+              default:
+                throw new Error('Unexpected render');
+            }
+
+            previousLastUpdate = lastUpdate;
+            return (
+              <button data-testid="update-button" onClick={() => setState(!state)}>Force Update</button>
+            );
           })}
           {React.createElement(() => {
             useSplitClient({ splitKey: 'user_2', updateOnSdkTimedout: false });
@@ -149,6 +176,7 @@ describe('useSplitClient', () => {
     act(() => user2Client.__emitter__.emit(Event.SDK_READY));
     act(() => mainClient.__emitter__.emit(Event.SDK_UPDATE));
     act(() => user2Client.__emitter__.emit(Event.SDK_UPDATE));
+    act(() => fireEvent.click(getByTestId('update-button')));
 
     // SplitFactoryProvider renders once
     expect(countSplitContext).toEqual(1);
@@ -160,7 +188,7 @@ describe('useSplitClient', () => {
     expect(countUseSplitClientUser2).toEqual(5);
 
     // If useSplitClient retrieves the main client and have updateOnSdkUpdate = false, it doesn't render when the main client updates.
-    expect(countUseSplitClientWithoutUpdate).toEqual(3);
+    expect(countUseSplitClientWithoutUpdate).toEqual(4);
 
     // If useSplitClient retrieves a different client and have updateOnSdkTimedout = false, it doesn't render when the the new client times out.
     expect(countUseSplitClientUser2WithoutTimeout).toEqual(4);

--- a/src/useSplitClient.ts
+++ b/src/useSplitClient.ts
@@ -37,8 +37,10 @@ export function useSplitClient(options?: IUseSplitClientOptions): ISplitContextV
 
   initAttributes(client, attributes);
 
-  const status = getStatus(client);
-  const [, setLastUpdate] = React.useState(status.lastUpdate);
+  const [lastUpdate, setLastUpdate] = React.useState(0);
+  // `getStatus` is not pure. Its result depends on `client` and `lastUpdate`
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const status = React.useMemo(() => getStatus(client), [client, lastUpdate]);
 
   // Handle client events
   React.useEffect(() => {


### PR DESCRIPTION
# React SDK

## What did you accomplish?

Fix a wrong behaviour with `useSplitClient` hook, that was not properly memoizing the internal client status according to the provided `updateOn<Event>` options, resulting in unexpected re-evaluations when the SDK was updated and the hook function re-called due to a re-render in the component.

## How do we test the changes introduced in this PR?

Added tests to avoid regressions.

## Extra Notes
